### PR TITLE
Add NotificationCenter notification when a sync was successful.

### DIFF
--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -300,6 +300,7 @@ extension SyncEngine {
             }
             self?.zoneChangesToken = token
             callback?()
+            NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: "icecream.sync.successful")))
             print("Sync successfully!")
         }
         privateDatabase.add(changesOp)


### PR DESCRIPTION
When an iCloud sync was successful (and data has changed), it would be very useful to notify the app of those changes, so it can update its UI. This might be the case when two devices of the same account use the app at the same time (then we should display the changes immediately) or when installing the app on a new device and fetching the existing data from iCloud (we then need to show the existing data).

My added line of code fires a notification through NotificationCenter with the name `"icecream.sync.successful"`, so the app can subscribe to this notification and handle changes as it sees fit.