### PR TITLE
Handle CKError.changeTokenExpired

### DIFF
--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -451,12 +451,12 @@ extension SyncEngine {
                 })
             }
         case .changeTokenExpired:
-            // The change token is no longer valid and must be resynced.
+            /// The previousServerChangeToken value is too old and the client must re-sync from scratch
             zoneChangesToken = nil
             databaseChangeToken = nil
             block()
         default:
-            print("Error: \(e.localizedDescription) (\(e.code.rawValue))")
+            print("CKError Details: \(e.localizedDescription) CKError Code: (\(e.code.rawValue))")
         }
     }
 }

--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -157,7 +157,7 @@ extension SyncEngine {
         }
         set {
             guard let n = newValue else {
-                UserDefaults.standard.setNilValueForKey(IceCreamKey.databaseChangesTokenKey.value)
+                UserDefaults.standard.removeObject(forKey: IceCreamKey.databaseChangesTokenKey.value)
                 return
             }
             let data = NSKeyedArchiver.archivedData(withRootObject: n)
@@ -174,7 +174,7 @@ extension SyncEngine {
         }
         set {
             guard let n = newValue else {
-                UserDefaults.standard.setNilValueForKey(IceCreamKey.zoneChangesTokenKey.value)
+                UserDefaults.standard.removeObject(forKey: IceCreamKey.zoneChangesTokenKey.value)
                 return
             }
             let data = NSKeyedArchiver.archivedData(withRootObject: n)
@@ -450,8 +450,12 @@ extension SyncEngine {
                     block()
                 })
             }
+        case .changeTokenExpired:
+            // The change token is no longer valid and must be resynced.
+            zoneChangesToken = nil
+            block()
         default:
-            print("Error: " + e.localizedDescription)
+            print("Error: \(e.localizedDescription) (\(e.code.rawValue))")
         }
     }
 }

--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -453,6 +453,7 @@ extension SyncEngine {
         case .changeTokenExpired:
             // The change token is no longer valid and must be resynced.
             zoneChangesToken = nil
+            databaseChangeToken = nil
             block()
         default:
             print("Error: \(e.localizedDescription) (\(e.code.rawValue))")


### PR DESCRIPTION
This PR handles CKError.changeTokenExpired by deleting the stored token and retrying the request.

This fixes errors such as the following:
```
Error: Error fetching changes in zone <CKRecordZoneID: 0x151f6c9c0; ownerName=__defaultOwner__, zoneName=CarsZone>: client knowledge differs from server knowledge
```

Use UserDefaults.removeObject(forKey:) instead of NSObject.setNilValueForKey() because the latter raises an NSInvalidArgumentException.