### PR TITLE
If object is nil, need to convert as Realm Object

### DIFF
--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -44,11 +44,13 @@ extension CKRecordRecoverable {
             case .data:
                 recordValue = record.value(forKey: prop.name) as? Data
             case .object:
-                if record.value(forKey: prop.name) == nil {
-                    //This step is for setting nil CreamAsset to Object. Otherwise, it may cause error
-                    recordValue = record.value(forKey: prop.name) as? Object
-                } else {
-                    print("For now, the Object only support CKAsset related type.")
+                guard let asset = record.value(forKey: prop.name) as? CKAsset else {
+                    if record.value(forKey: prop.name) == nil {
+                        //This step is for setting nil CreamAsset to Object. Otherwise, it may cause error
+                        recordValue = record.value(forKey: prop.name) as? Object
+                    } else {
+                        print("For now, the Object only support CKAsset related type.")
+                    }
                     break
                 }
                 recordValue = CreamAsset.parse(from: prop.name, record: record, asset: asset)

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -49,6 +49,7 @@ extension CKRecordRecoverable {
                     recordValue = record.value(forKey: prop.name) as? Object
                 } else {
                     print("For now, the Object only support CKAsset related type.")
+                    break
                 }
                 recordValue = CreamAsset.parse(from: prop.name, record: record, asset: asset)
             default:

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -44,9 +44,11 @@ extension CKRecordRecoverable {
             case .data:
                 recordValue = record.value(forKey: prop.name) as? Data
             case .object:
-                guard let asset = record.value(forKey: prop.name) as? CKAsset else {
+                if record.value(forKey: prop.name) == nil {
+                    //This step is for setting nil CreamAsset to Object. Otherwise, it may cause error
+                    recordValue = record.value(forKey: prop.name) as? Object
+                } else {
                     print("For now, the Object only support CKAsset related type.")
-                    break
                 }
                 recordValue = CreamAsset.parse(from: prop.name, record: record, asset: asset)
             default:


### PR DESCRIPTION
If set CreamAsset as nil and then in another device, new install, and when sync it may cause these two error:

Error1:

> Terminating app due to uncaught exception 'RLMException', reason: 'Invalid value 'some valuse' to initialize object of type 'CreamAsset': missing key 'uniqueFileName''

Error2:

> -[NSTaggedPointerString uniqueFileName]: unrecognized selector sent to instance 0xa373337333733237
2018-02-05 14:11:19.547784+1300 inkDiary[4761:1906170] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSTaggedPointerString uniqueFileName]: unrecognized selector sent to instance 0xa373337333733237'
*** First throw call stack:
(0x185c1e364 0x184e64528 0x185c2b828 0x185c23d10 0x185b08ecc 0x104f96010 0x104e8529c 0x104e84388 0x186515ec4 0x185bb033c 0x185baf8dc 0x185baf640 0x185c2d024 0x185ae5f60 0x186513348 0x104f91a08 0x104dd2ed8 0x10778d2cc 0x10778d28c 0x107791ea0 0x185bc6544 0x185bc4120 0x185ae3e58 0x187990f84 0x18f16367c 0x104dfa874 0x18560056c)
libc++abi.dylib: terminating with uncaught exception of type NSException


Feel free ask me more details. ^ ^