### PR TITLE
Better handling of CKAsset

### DIFF
--- a/Example/IceCream/Dog.swift
+++ b/Example/IceCream/Dog.swift
@@ -16,6 +16,8 @@ class Dog: Object {
     @objc dynamic var name = ""
     @objc dynamic var age = 0
     @objc dynamic var isDeleted = false
+
+    static let AVATAR_KEY = "avatar"
     @objc dynamic var avatar: CreamAsset?
     
     override class func primaryKey() -> String? {

--- a/Example/IceCream/ViewController.swift
+++ b/Example/IceCream/ViewController.swift
@@ -67,7 +67,7 @@ class ViewController: UIViewController {
       dog.age = dogs.count + 1
 
       let data = UIImageJPEGRepresentation(UIImage(named: dog.age % 2 == 1 ? "smile_dog" : "tongue_dog")!, 1.0) as Data!
-      dog.avatar = CreamAsset.create(object: dog, propName: "avatar", data: data!)
+      dog.avatar = CreamAsset.create(object: dog, propName: Dog.AVATAR_KEY, data: data!)
       try! realm.write {
         realm.add(dog)
       }
@@ -105,7 +105,7 @@ extension ViewController: UITableViewDelegate {
             let dog = `self`.dogs[ip.row]
             try! `self`.realm.write {
                 if let imageData = UIImageJPEGRepresentation(UIImage(named: dog.age % 2 == 0 ? "smile_dog" : "tongue_dog")!, 1.0) {
-                  dog.avatar = CreamAsset.create(object: dog, propName: "avatar", data: imageData)
+                  dog.avatar = CreamAsset.create(object: dog, propName: Dog.AVATAR_KEY, data: imageData)
                 }
             }
         }

--- a/Example/IceCream/ViewController.swift
+++ b/Example/IceCream/ViewController.swift
@@ -62,15 +62,16 @@ class ViewController: UIViewController {
     }
     
     @objc func add() {
-        let dog = Dog()
-        dog.name = "Dog Number " + "\(dogs.count)"
-        dog.age = dogs.count + 1
-        dog.avatar = CreamAsset(uniqueKey: dog.id, data: UIImageJPEGRepresentation(UIImage(named: dog.age % 2 == 1 ? "smile_dog" : "tongue_dog")!, 1.0) as Data!)
-        try! realm.write {
-            realm.add(dog)
-        }
-    }
-    
+      let dog = Dog()
+      dog.name = "Dog Number " + "\(dogs.count)"
+      dog.age = dogs.count + 1
+
+      let data = UIImageJPEGRepresentation(UIImage(named: dog.age % 2 == 1 ? "smile_dog" : "tongue_dog")!, 1.0) as Data!
+      dog.avatar = CreamAsset.create(object: dog, propName: "avatar", data: data!)
+      try! realm.write {
+        realm.add(dog)
+      }
+  }
 }
 
 extension ViewController: UITableViewDelegate {
@@ -104,7 +105,7 @@ extension ViewController: UITableViewDelegate {
             let dog = `self`.dogs[ip.row]
             try! `self`.realm.write {
                 if let imageData = UIImageJPEGRepresentation(UIImage(named: dog.age % 2 == 0 ? "smile_dog" : "tongue_dog")!, 1.0) {
-                    dog.avatar = CreamAsset(uniqueKey: dog.id, data: imageData)
+                  dog.avatar = CreamAsset.create(object: dog, propName: "avatar", data: imageData)
                 }
             }
         }

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -101,12 +101,10 @@ extension CKRecordConvertible where Self: Object {
                 if objectName == CreamAsset.className() {
                     if let creamAsset = self[prop.name] as? CreamAsset {
                         r[prop.name] = creamAsset.asset
-                        r[prop.name + CreamAsset.assetPathSuffix] = creamAsset.uniqueFileName as CKRecordValue
                     } else {
                         /// Just a warm hint:
                         /// When we set nil to the property of a CKRecord, that record's property will be hidden in the CloudKit Dashboard
                         r[prop.name] = nil
-                        r[prop.name + CreamAsset.assetPathSuffix] = nil
                     }
                 }
             default:

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -57,8 +57,6 @@ public class CreamAsset: Object {
     }
     
   static func parse(from propName: String, record: CKRecord, asset: CKAsset) -> CreamAsset? {
-//    let assetPathKey = propName + CreamAsset.assetPathSuffix
-//    guard let assetPathValue = record.value(forKey: assetPathKey) as? String else { return nil }
     guard let assetData = NSData(contentsOfFile: asset.fileURL.path) as Data? else { return nil }
 
     return CreamAsset(objectID: record.recordID.recordName,

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -18,21 +18,19 @@ import CloudKit
 /// We choose the latter, that's storing it directly on the file system, storing paths to these files in the Realm.
 /// So this is the deal.
 public class CreamAsset: Object {
-    public static let assetPathSuffix: String = "AssetPath"
-    
     @objc dynamic var uniqueFileName = ""
     @objc dynamic var data: Data?
     override public static func ignoredProperties() -> [String] {
         return ["data"]
     }
-    
-    public convenience init(uniqueKey: String, data: Data) {
+
+  private convenience init(objectID: String, propName: String, data: Data) {
         self.init()
         self.data = data
-        self.uniqueFileName = "\(uniqueKey)_\(UUID().uuidString)"
+        self.uniqueFileName = "\(objectID)_\(propName)"
         save(data: data, to: uniqueFileName)
     }
-    
+
     /// There is an important point that we need to consider:
     /// Cuz we only store the path of data, so we can't access data by `data` property
     /// So use this method if you want get the data of this object
@@ -58,19 +56,21 @@ public class CreamAsset: Object {
         }
     }
     
-    static func parse(from propName: String, record: CKRecord, asset: CKAsset) -> CreamAsset? {
-        let assetPathKey = propName + CreamAsset.assetPathSuffix
-        guard let assetPathValue = record.value(forKey: assetPathKey) as? String else { return nil }
-        guard let assetData = NSData(contentsOfFile: asset.fileURL.path) as Data? else { return nil }
-        let asset = CreamAsset()
-        asset.uniqueFileName = assetPathValue
-        asset.data = assetData
-        // Local cache not exist, save it to local files
-        if !CreamAsset.creamAssetFilesPaths().contains(assetPathValue) {
-            try! assetData.write(to: creamAssetDefaultURL().appendingPathComponent(assetPathValue))
-        }
-        return asset
-    }
+  static func parse(from propName: String, record: CKRecord, asset: CKAsset) -> CreamAsset? {
+//    let assetPathKey = propName + CreamAsset.assetPathSuffix
+//    guard let assetPathValue = record.value(forKey: assetPathKey) as? String else { return nil }
+    guard let assetData = NSData(contentsOfFile: asset.fileURL.path) as Data? else { return nil }
+
+    return CreamAsset(objectID: record.recordID.recordName,
+                      propName: propName,
+                      data: assetData)
+  }
+
+  public static func create(object: CKRecordConvertible, propName: String, data: Data) -> CreamAsset? {
+    return CreamAsset(objectID: object.recordID.recordName,
+                      propName: propName,
+                           data: data)
+  }
 }
 
 extension CreamAsset {


### PR DESCRIPTION
Following issue #29, this PR simplifies the creation and update of an CreamAsset.

The filename is no longer based on UUID, but a simple concatenation of objectID and property name.
As a consequence, it is no longer needed to store the filename of the asset on iCloud.

