### PR TITLE
Observe and commitWrite work on background thread.

### DIFF
--- a/IceCream/Classes/BackgroundWorker.swift
+++ b/IceCream/Classes/BackgroundWorker.swift
@@ -1,0 +1,49 @@
+//
+//  BackgroundWorker.swift
+//  IceCream
+//
+//  Created by Fu Yuan on 7/02/18.
+//
+
+import Foundation
+
+class BackgroundWorker: NSObject {
+    private var thread: Thread!
+    private var block: (()->Void)!
+    
+    @objc internal func runBlock() { block() }
+    
+    private func createThread() {
+        let threadName = String(describing: self)
+            .components(separatedBy: .punctuationCharacters)[1]
+        
+        thread = Thread { [weak self] in
+            while (self != nil && !self!.thread.isCancelled) {
+                RunLoop.current.run(
+                    mode: RunLoopMode.defaultRunLoopMode,
+                    before: Date.distantPast)
+            }
+            Thread.exit()
+        }
+        thread.name = "\(threadName)-\(UUID().uuidString)"
+        thread.start()
+    }
+    
+    internal func start(_ block: @escaping () -> Void) {
+        self.block = block
+        
+        if thread == nil {
+            createThread()
+        }
+        
+        perform(#selector(runBlock),
+                on: thread,
+                with: nil,
+                waitUntilDone: false,
+                modes: [RunLoopMode.defaultRunLoopMode.rawValue])
+    }
+    
+    public func stop() {
+        thread.cancel()
+    }
+}


### PR DESCRIPTION
I met a problem that if there are huge data will pull from iCloud, then `commitWrite` in some cases may stuck Main thread. So this PR is for solving this problem. 

`notifications` can work on background thread according to [Realm Notifications on Background Threads with Swift](https://academy.realm.io/posts/realm-notifications-on-background-threads-with-swift/) and [commitWrite(withoutNotifying:)](https://realm.io/docs/swift/latest/api/Classes/Realm.html#/s:FC10RealmSwift5Realm11commitWriteFzT16withoutNotifyingGSaCSo20RLMNotificationToken__T_) need to work on the same thread with `notifications`. Therefore, I created a new class `BackgroundWorker`.

There is a tiny problem, that `cleanup` method need to work on this background thread as well, so it can not work on `UIApplicationWillTerminate`. Instead, I use `UIApplicationWillResignActive` to solve this problem.