### PR TITLE
Public database working

### DIFF
--- a/IceCream.podspec
+++ b/IceCream.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'IceCream'
-  s.version          = '1.3.4'
+  s.version          = '1.3.1'
   s.summary          = 'Sync Realm with CloudKit'
   s.description      = <<-DESC
   Sync Realm Database with CloudKit, written in Swift. It works just like magic.

--- a/IceCream.podspec
+++ b/IceCream.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'IceCream'
-  s.version          = '1.3.1'
+  s.version          = '1.3.2'
   s.summary          = 'Sync Realm with CloudKit'
   s.description      = <<-DESC
   Sync Realm Database with CloudKit, written in Swift. It works just like magic.

--- a/IceCream.podspec
+++ b/IceCream.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'IceCream'
-  s.version          = '1.3.2'
+  s.version          = '1.3.4'
   s.summary          = 'Sync Realm with CloudKit'
   s.description      = <<-DESC
   Sync Realm Database with CloudKit, written in Swift. It works just like magic.

--- a/IceCream.podspec
+++ b/IceCream.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'IceCream'
-  s.version          = '1.3.0'
+  s.version          = '1.3.1'
   s.summary          = 'Sync Realm with CloudKit'
   s.description      = <<-DESC
   Sync Realm Database with CloudKit, written in Swift. It works just like magic.

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -117,4 +117,13 @@ extension CKRecordConvertible where Self: Object {
     
 }
 
+protocol IceCreamRecordConvertiblePublic {
+    var customZoneID: CKRecordZoneID { get }
+}
+
+extension IceCreamRecordConvertiblePublic {
+    public var customZoneID: CKRecordZoneID {
+        return CKRecordZone.default().zoneID
+    }
+}
 

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -79,10 +79,17 @@ extension CKRecordConvertible where Self: Object {
             fatalError("You should set a primary key on your Realm object")
         }
         
+        let zoneID: CKRecordZoneID
+        if self is StoredInPublicDatabase {
+            zoneID = CKRecordZone.default().zoneID
+        } else {
+            zoneID = Self.customZoneID
+        }
+        
         if let primaryValueString = self[primaryKeyProperty.name] as? String {
-            return CKRecordID(recordName: primaryValueString, zoneID: Self.customZoneID)
+            return CKRecordID(recordName: primaryValueString, zoneID: zoneID)
         } else if let primaryValueInt = self[primaryKeyProperty.name] as? Int {
-            return CKRecordID(recordName: "\(primaryValueInt)", zoneID: Self.customZoneID)
+            return CKRecordID(recordName: "\(primaryValueInt)", zoneID: zoneID)
         } else {
             fatalError("Primary key should be String or Int")
         }
@@ -117,13 +124,5 @@ extension CKRecordConvertible where Self: Object {
     
 }
 
-public protocol IceCreamRecordConvertiblePublic {
-    var customZoneID: CKRecordZoneID { get }
+public protocol StoredInPublicDatabase {
 }
-
-extension IceCreamRecordConvertiblePublic {
-    public var customZoneID: CKRecordZoneID {
-        return CKRecordZone.default().zoneID
-    }
-}
-

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -117,7 +117,7 @@ extension CKRecordConvertible where Self: Object {
     
 }
 
-protocol IceCreamRecordConvertiblePublic {
+public protocol IceCreamRecordConvertiblePublic {
     var customZoneID: CKRecordZoneID { get }
 }
 

--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -44,13 +44,19 @@ public final class SyncEngine<T: Object & CKRecordConvertible & CKRecordRecovera
     
 //    fileprivate var changedRecordZoneID: CKRecordZoneID?
     
-    /// Indicates the private database in default container
-    private let privateDatabase = CKContainer.default().privateCloudDatabase
+    /// Indicates the database in default container
+    private let database: CKDatabase
     
     private let errorHandler = ErrorHandler()
     
     /// We recommand process the initialization when app launches
-    public init() {
+    public init(usePublicDatabase: Bool = false) {
+        if usePublicDatabase {
+            database = CKContainer.default().publicCloudDatabase
+        } else {
+            database = CKContainer.default().privateCloudDatabase
+        }
+        
         /// Check iCloud status so that we can go on
         CKContainer.default().accountStatus { [weak self] (status, error) in
             guard let `self` = self else { return }
@@ -266,7 +272,7 @@ extension SyncEngine {
                 return
             }
         }
-        privateDatabase.add(changesOperation)
+        database.add(changesOperation)
     }
     
     private func fetchChangesInZone(_ callback: (() -> Void)? = nil) {
@@ -350,7 +356,7 @@ extension SyncEngine {
             }
         }
         
-        privateDatabase.add(changesOp)
+        database.add(changesOp)
     }
  
     
@@ -375,7 +381,7 @@ extension SyncEngine {
             }
         }
         
-        privateDatabase.add(modifyOp)
+        database.add(modifyOp)
     }
  
     /// Check if custom zone already exists
@@ -424,7 +430,7 @@ extension SyncEngine {
         notificationInfo.shouldSendContentAvailable = true // Silent Push
         subscription.notificationInfo = notificationInfo
         
-        privateDatabase.save(subscription) { [weak self](_, error) in
+        database.save(subscription) { [weak self](_, error) in
             guard let `self` = self else { return }
             switch `self`.errorHandler.resultType(with: error) {
             case .success:
@@ -503,7 +509,7 @@ extension SyncEngine {
             }
         }
         
-        privateDatabase.add(modifyOpe)
+        database.add(modifyOpe)
     }
 }
 


### PR DESCRIPTION
This version appears to be working...
 
Tell SyncEngine to use public database:

`let syncEngine = SyncEngine<MyObject>(usePublicDatabase: true)
`

Mark objects to be stored in public database:

`extension MyObject: StoredInPublicDatabase {}
`
