### PR TITLE
Enable static framework support through CocoaPods

### DIFF
--- a/Example/IceCream_Example.xcodeproj/project.pbxproj
+++ b/Example/IceCream_Example.xcodeproj/project.pbxproj
@@ -212,7 +212,6 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-IceCream_Example/Pods-IceCream_Example-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/IceCream/IceCream.framework",
 				"${BUILT_PRODUCTS_DIR}/Realm/Realm.framework",
 				"${BUILT_PRODUCTS_DIR}/RealmSwift/RealmSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/RxRealm/RxRealm.framework",
@@ -220,7 +219,6 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IceCream.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Realm.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RealmSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxRealm.framework",

--- a/IceCream.podspec
+++ b/IceCream.podspec
@@ -21,6 +21,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '10.0'
   s.source_files = 'IceCream/Classes/**/*'
+  s.static_framework = true
 
   s.dependency 'RealmSwift'
 end


### PR DESCRIPTION
This PR sets the `static_framework` flag in the podspec to enable support for static frameworks.

See http://blog.cocoapods.org/CocoaPods-1.4.0/