### PR TITLE
Add alternative way to setup subscriptions

### DIFF
--- a/IceCream/Classes/Manifest.swift
+++ b/IceCream/Classes/Manifest.swift
@@ -17,7 +17,16 @@ public class IceCream {
     /// If you don't want to see them in your console, just set `enableLogging` property to false.
     /// The default value is true.
     public var enableLogging: Bool = true
+    /// Subscription method enables setting a different CloudKit subscription method for all the SyncEngine's you use
+    /// There's Apple recommended way and default alternative way
+    /// Alternative way didn't work for all cases so if you have problems not receiving silent pushes try Apple subscription method
+    public var subscriptionMethod: SubscriptionMethod = .alternative
     
+}
+
+public enum SubscriptionMethod {
+    case appleSuggested
+    case alternative
 }
 
 /// If you want to know more,


### PR DESCRIPTION
I've found that the default way to create subscriptions don't work on my case but the commented out Apple way worked.

### What didn't work

Silent push notifications didn't work with the default subscription creation method. Maybe it's because I'm using multiple SyncEngine instances to sync different types.

### What have I changed

I've added a new setting in the singleton to use the Apple way of creating subscriptions.

### What did I break

Nothing. Default value should call the current way of subscribing so current users don't see any difference.