### PR TITLE
Expose file path, init with URL

### DIFF
--- a/IceCream.xcodeproj/project.pbxproj
+++ b/IceCream.xcodeproj/project.pbxproj
@@ -199,7 +199,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "EXPANDED_CODE_SIGN_IDENTITY='' /usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/IceCream.xcodeproj/project.pbxproj
+++ b/IceCream.xcodeproj/project.pbxproj
@@ -199,7 +199,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "EXPANDED_CODE_SIGN_IDENTITY='' /usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -24,21 +24,16 @@ public class CreamAsset: Object {
         return ["data", "filePath"]
     }
 
-    private convenience init(objectID: String, propName: String, data: Data, fileExtension: String?) {
+    private convenience init(objectID: String, propName: String, data: Data) {
         self.init()
         self.data = data
-        var suffix = ""
-        if let fileExtension = fileExtension,
-            !fileExtension.isEmpty {
-            suffix = ".\(fileExtension)"
-        }
-        self.uniqueFileName = "\(objectID)_\(propName)\(suffix)"
+        self.uniqueFileName = "\(objectID)_\(propName)"
         save(data: data, to: uniqueFileName)
     }
 
     private convenience init?(objectID: String, propName: String, url: URL) {
         guard let data = try? Data(contentsOf: url) else { return nil }
-        self.init(objectID: objectID, propName: propName, data: data, fileExtension: url.pathExtension)
+        self.init(objectID: objectID, propName: propName, data: data)
     }
 
     /// There is an important point that we need to consider:
@@ -86,13 +81,11 @@ public class CreamAsset: Object {
     ///   - object: The object the asset will live on
     ///   - propName: The unique property name to identify this asset. **Must match the property name on the object where it will be stored!**
     ///   - data: The file data
-    ///   - fileExtension: An optional file extension if you want to maintain that information in the filename/url.  e.g. "mov"
     /// - Returns: A CreamAsset if it was successful
-    public static func create(object: CKRecordConvertible, propName: String, data: Data, fileExtension: String? = nil) -> CreamAsset? {
+    public static func create(object: CKRecordConvertible, propName: String, data: Data) -> CreamAsset? {
         return CreamAsset(objectID: object.recordID.recordName,
                           propName: propName,
-                          data: data,
-                          fileExtension: fileExtension)
+                          data: data)
     }
 
     /// Creates a new CreamAsset for the given object with a URL

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -35,9 +35,10 @@ public class CreamAsset: Object {
     /// Cuz we only store the path of data, so we can't access data by `data` property
     /// So use this method if you want get the data of this object
     public func storedData() -> Data? {
-        let filePath = CreamAsset.creamAssetDefaultURL().appendingPathComponent(uniqueFileName)
         return try! Data(contentsOf: filePath)
     }
+    
+    public lazy var filePath: URL = CreamAsset.creamAssetDefaultURL().appendingPathComponent(uniqueFileName)
     
     func save(data: Data, to path: String) {
         let url = CreamAsset.creamAssetDefaultURL().appendingPathComponent(path)
@@ -50,7 +51,7 @@ public class CreamAsset: Object {
     
     var asset: CKAsset {
         get {
-            let diskCachePath = CreamAsset.creamAssetDefaultURL().appendingPathComponent(uniqueFileName)
+            let diskCachePath = filePath
             let uploadAsset = CKAsset(fileURL: diskCachePath)
             return uploadAsset
         }

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -58,9 +58,7 @@ public class CreamAsset: Object {
 
     var asset: CKAsset {
         get {
-            let diskCachePath = filePath
-            let uploadAsset = CKAsset(fileURL: diskCachePath)
-            return uploadAsset
+            return CKAsset(fileURL: filePath)
         }
     }
 

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -65,7 +65,7 @@ public class CreamAsset: Object {
     /// Parses a CKRecord and CKAsset back into a CreamAsset
     ///
     /// - Parameters:
-    ///   - propName: The unique property name to identify this asset. **Must match the property name on the object where it will be stored!**
+    ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
     ///   - record: The CKRecord where we will pull the record ID off of to locate/store the file
     ///   - asset: The CKAsset where we will pull the URL for creating the asset
     /// - Returns: A CreamAsset if it was successful
@@ -77,7 +77,7 @@ public class CreamAsset: Object {
     ///
     /// - Parameters:
     ///   - object: The object the asset will live on
-    ///   - propName: The unique property name to identify this asset. **Must match the property name on the object where it will be stored!**
+    ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
     ///   - data: The file data
     /// - Returns: A CreamAsset if it was successful
     public static func create(object: CKRecordConvertible, propName: String, data: Data) -> CreamAsset? {
@@ -90,7 +90,7 @@ public class CreamAsset: Object {
     ///
     /// - Parameters:
     ///   - object: The object the asset will live on
-    ///   - propName: The unique property name to identify this asset. **Must match the property name on the object where it will be stored!**
+    ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
     ///   - url: The URL of the file to store. Any path extension on the file (e.g. "mov") will be maintained
     /// - Returns: A CreamAsset if it was successful
     public static func create(object: CKRecordConvertible, propName: String, url: URL) -> CreamAsset? {


### PR DESCRIPTION
In addition to my previous work of exposing the file path, this allows the consumer to specify a file extension to maintain throughout the life of the asset, and also to initialize the CreamAsset with a URL instead of data.