### PR TITLE
Update syntax for swift 4.2 and Xcode 10

### DIFF
--- a/IceCream.xcodeproj/project.pbxproj
+++ b/IceCream.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 				TargetAttributes = {
 					6743F711202B0F0F00912163 = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -356,7 +357,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.soledad.http.IceCream;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -380,7 +381,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.soledad.http.IceCream;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -11,9 +11,9 @@ import RealmSwift
 
 public protocol CKRecordConvertible {
     static var recordType: String { get }
-    static var customZoneID: CKRecordZoneID { get }
+    static var customZoneID: CKRecordZone.ID { get }
     
-    var recordID: CKRecordID { get }
+    var recordID: CKRecord.ID { get }
     var record: CKRecord { get }
     
     var isDeleted: Bool { get }
@@ -25,13 +25,13 @@ extension CKRecordConvertible where Self: Object {
         return className()
     }
     
-    public static var customZoneID: CKRecordZoneID {
-        return CKRecordZoneID(zoneName: "\(recordType)sZone", ownerName: CKCurrentUserDefaultName)
+    public static var customZoneID: CKRecordZone.ID {
+        return CKRecordZone.ID(zoneName: "\(recordType)sZone", ownerName: CKCurrentUserDefaultName)
     }
     
     /// recordName : this is the unique identifier for the record, used to locate records on the database. We can create our own ID or leave it to CloudKit to generate a random UUID.
     /// For more: https://medium.com/@guilhermerambo/synchronizing-data-with-cloudkit-94c6246a3fda
-    public var recordID: CKRecordID {
+    public var recordID: CKRecord.ID {
         guard let sharedSchema = Self.sharedSchema() else {
             fatalError("No schema settled. Go to Realm Community to seek more help.")
         }
@@ -41,9 +41,9 @@ extension CKRecordConvertible where Self: Object {
         }
         
         if let primaryValueString = self[primaryKeyProperty.name] as? String {
-            return CKRecordID(recordName: primaryValueString, zoneID: Self.customZoneID)
+            return CKRecord.ID(recordName: primaryValueString, zoneID: Self.customZoneID)
         } else if let primaryValueInt = self[primaryKeyProperty.name] as? Int {
-            return CKRecordID(recordName: "\(primaryValueInt)", zoneID: Self.customZoneID)
+            return CKRecord.ID(recordName: "\(primaryValueInt)", zoneID: Self.customZoneID)
         } else {
             fatalError("Primary key should be String or Int")
         }

--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -91,7 +91,7 @@ public final class SyncEngine {
                     }
                 }
                 
-                NotificationCenter.default.addObserver(self, selector: #selector(`self`.cleanUp), name: .UIApplicationWillTerminate, object: nil)
+                NotificationCenter.default.addObserver(self, selector: #selector(`self`.cleanUp), name: UIApplication.willTerminateNotification, object: nil)
                 
                 /// 3. Create the subscription to the CloudKit database
                 if `self`.subscriptionIsLocallyCached { return }
@@ -216,14 +216,14 @@ extension SyncEngine {
         privateDatabase.add(changesOperation)
     }
 
-    private var zoneIds: [CKRecordZoneID] {
+    private var zoneIds: [CKRecordZone.ID] {
         return syncObjects.map { $0.customZoneID }
     }
 
-    private var zoneIdOptions: [CKRecordZoneID: CKFetchRecordZoneChangesOptions] {
-        return syncObjects.reduce([CKRecordZoneID: CKFetchRecordZoneChangesOptions]()) { (dict, syncEngine) -> [CKRecordZoneID: CKFetchRecordZoneChangesOptions] in
+    private var zoneIdOptions: [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions] {
+        return syncObjects.reduce([CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions]()) { (dict, syncEngine) -> [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions] in
             var dict = dict
-            let zoneChangesOptions = CKFetchRecordZoneChangesOptions()
+            let zoneChangesOptions = CKFetchRecordZoneChangesOperation.ZoneOptions()
             zoneChangesOptions.previousServerChangeToken = syncEngine.zoneChangesToken
             dict[syncEngine.customZoneID] = zoneChangesOptions
             return dict
@@ -289,7 +289,7 @@ extension SyncEngine {
 
         let subscription = CKDatabaseSubscription(subscriptionID: IceCreamConstant.cloudKitSubscriptionID)
 
-        let notificationInfo = CKNotificationInfo()
+        let notificationInfo = CKSubscription.NotificationInfo()
         notificationInfo.shouldSendContentAvailable = true // Silent Push
 
         subscription.notificationInfo = notificationInfo
@@ -343,11 +343,11 @@ extension SyncEngine {
 extension SyncEngine {
     /// Sync local data to CloudKit
     /// For more about the savePolicy: https://developer.apple.com/documentation/cloudkit/ckrecordsavepolicy
-    public func syncRecordsToCloudKit(recordsToStore: [CKRecord], recordIDsToDelete: [CKRecordID], completion: ((Error?) -> ())? = nil) {
+    public func syncRecordsToCloudKit(recordsToStore: [CKRecord], recordIDsToDelete: [CKRecord.ID], completion: ((Error?) -> ())? = nil) {
         let modifyOpe = CKModifyRecordsOperation(recordsToSave: recordsToStore, recordIDsToDelete: recordIDsToDelete)
         
         if #available(iOS 11.0, *) {
-            let config = CKOperationConfiguration()
+            let config = CKOperation.Configuration()
             config.isLongLived = true
             modifyOpe.configuration = config
         } else {

--- a/IceCream/Classes/SyncObject.swift
+++ b/IceCream/Classes/SyncObject.swift
@@ -23,7 +23,7 @@ public final class SyncObject<T> where T: Object & CKRecordConvertible & CKRecor
     
     private let errorHandler = ErrorHandler()
     
-    public var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecordID]) -> ())?
+    public var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecord.ID]) -> ())?
     
     public init() {}
 }
@@ -36,7 +36,7 @@ extension SyncObject: Syncable {
         return T.recordType
     }
     
-    public var customZoneID: CKRecordZoneID {
+    public var customZoneID: CKRecordZone.ID {
         return T.customZoneID
     }
     
@@ -89,7 +89,7 @@ extension SyncObject: Syncable {
         }
     }
     
-    public func delete(recordID: CKRecordID) {
+    public func delete(recordID: CKRecord.ID) {
         DispatchQueue.main.async {
             let realm = try! Realm()
             guard let object = realm.object(ofType: T.self, forPrimaryKey: recordID.recordName) else {

--- a/IceCream/Classes/Syncable.swift
+++ b/IceCream/Classes/Syncable.swift
@@ -14,7 +14,7 @@ public protocol Syncable: class {
     
     /// CKRecordZone related
     var recordType: String { get }
-    var customZoneID: CKRecordZoneID { get }
+    var customZoneID: CKRecordZone.ID { get }
     
     /// Local storage
     var zoneChangesToken: CKServerChangeToken? { get set }
@@ -24,8 +24,8 @@ public protocol Syncable: class {
     func registerLocalDatabase()
     func cleanUp()
     func add(record: CKRecord)
-    func delete(recordID: CKRecordID)
+    func delete(recordID: CKRecord.ID)
     
     /// Callback
-    var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecordID]) -> ())? { get set }
+    var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecord.ID]) -> ())? { get set }
 }


### PR DESCRIPTION
This is simply running the swift syntax converter in Xcode 10 (to swift 4.2), confirming it compiles, and then committing that.