### PR TITLE
Sharing flow

### DIFF
--- a/Example/IceCream_Example/Cat.swift
+++ b/Example/IceCream_Example/Cat.swift
@@ -23,6 +23,10 @@ class Cat: Object {
     override class func primaryKey() -> String? {
         return "id"
     }
+
+    // required for sharing, observing public database
+    @objc dynamic var databaseType = DatabaseType.dbPrivate
+
 }
 
 extension Cat: CKRecordRecoverable {

--- a/Example/IceCream_Example/Dog.swift
+++ b/Example/IceCream_Example/Dog.swift
@@ -23,6 +23,10 @@ class Dog: Object {
     override class func primaryKey() -> String? {
         return "id"
     }
+    
+    // required for sharing, observing public database
+    @objc dynamic var databaseType = DatabaseType.dbPrivate
+
 }
 
 extension Dog: CKRecordConvertible {

--- a/IceCream.xcodeproj/project.pbxproj
+++ b/IceCream.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 				TargetAttributes = {
 					6743F711202B0F0F00912163 = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -356,7 +357,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.soledad.http.IceCream;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -380,7 +381,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.soledad.http.IceCream;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -11,9 +11,9 @@ import RealmSwift
 
 public protocol CKRecordConvertible {
     static var recordType: String { get }
-    static var customZoneID: CKRecordZoneID { get }
+    static var customZoneID: CKRecordZone.ID { get }
     
-    var recordID: CKRecordID { get }
+    var recordID: CKRecord.ID { get }
     var record: CKRecord { get }
     
     var isDeleted: Bool { get }
@@ -25,13 +25,13 @@ extension CKRecordConvertible where Self: Object {
         return className()
     }
     
-    public static var customZoneID: CKRecordZoneID {
-        return CKRecordZoneID(zoneName: "\(recordType)sZone", ownerName: CKCurrentUserDefaultName)
+    public static var customZoneID: CKRecordZone.ID {
+        return CKRecordZone.ID(zoneName: "\(recordType)sZone", ownerName: CKCurrentUserDefaultName)
     }
     
     /// recordName : this is the unique identifier for the record, used to locate records on the database. We can create our own ID or leave it to CloudKit to generate a random UUID.
     /// For more: https://medium.com/@guilhermerambo/synchronizing-data-with-cloudkit-94c6246a3fda
-    public var recordID: CKRecordID {
+    public var recordID: CKRecord.ID {
         guard let sharedSchema = Self.sharedSchema() else {
             fatalError("No schema settled. Go to Realm Community to seek more help.")
         }
@@ -41,9 +41,9 @@ extension CKRecordConvertible where Self: Object {
         }
         
         if let primaryValueString = self[primaryKeyProperty.name] as? String {
-            return CKRecordID(recordName: primaryValueString, zoneID: Self.customZoneID)
+            return CKRecord.ID(recordName: primaryValueString, zoneID: Self.customZoneID)
         } else if let primaryValueInt = self[primaryKeyProperty.name] as? Int {
-            return CKRecordID(recordName: "\(primaryValueInt)", zoneID: Self.customZoneID)
+            return CKRecord.ID(recordName: "\(primaryValueInt)", zoneID: Self.customZoneID)
         } else {
             fatalError("Primary key should be String or Int")
         }

--- a/IceCream/Classes/CKRecordRecoverable.swift
+++ b/IceCream/Classes/CKRecordRecoverable.swift
@@ -8,8 +8,29 @@
 import CloudKit
 import RealmSwift
 
+@objc public enum DatabaseType: Int {
+    case dbPrivate, dbShared
+    func description() -> String {
+        switch self {
+        case .dbPrivate:
+            return "dbPrivate"
+        case .dbShared:
+            return "dbShared"
+        }
+    }
+    func dataBase() -> CKDatabase {
+        let container = CKContainer.default()
+        switch self {
+        case .dbPrivate:
+            return container.privateCloudDatabase
+        case .dbShared:
+            return container.sharedCloudDatabase
+        }
+    }
+}
+
 public protocol CKRecordRecoverable {
-    
+    var databaseType: DatabaseType { get set }
 }
 
 extension CKRecordRecoverable where Self: Object {

--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -15,7 +15,9 @@ public enum Notifications: String, NotificationName {
 
 public enum IceCreamKey: String {
     /// Tokens
-    case databaseChangesTokenKey
+    case publicDatabaseChangesTokenKey
+    case privateDatabaseChangesTokenKey
+    case sharedDatabaseChangesTokenKey
     case zoneChangesTokenKey
 
     /// Flags
@@ -43,14 +45,11 @@ public struct IceCreamConstant {
 /// 3. it hands over CKRecordZone stuffs to SyncObject so that it can have an effect on local Realm Database
 
 public final class SyncEngine {
-
+    
     /// Notifications are delivered as long as a reference is held to the returned notification token. You should keep a strong reference to this token on the class registering for updates, as notifications are automatically unregistered when the notification token is deallocated.
     /// For more, reference is here: https://realm.io/docs/swift/latest/#notifications
     private var notificationToken: NotificationToken?
 
-    /// Indicates the private database in default container
-    private let privateDatabase = CKContainer.default().privateCloudDatabase
-    
     private let errorHandler = ErrorHandler()
     
     private let syncObjects: [Syncable]
@@ -74,8 +73,11 @@ public final class SyncEngine {
                 /// Apple suggests that we should fetch changes in database, *especially* the very first launch.
                 /// But actually, there **might** be some rare unknown and weird reason that the data is not synced between muilty devices.
                 /// So I suggests fetch changes in database everytime app launches.
-                `self`.fetchChangesInDatabase({
-                    print("First sync done!")
+                `self`.fetchChangesInDatabase(databaseType: .dbPrivate, {
+                    print("First private sync done!")
+                })
+                `self`.fetchChangesInDatabase(databaseType: .dbShared,{
+                    print("First shared sync done!")
                 })
 
                 `self`.resumeLongLivedOperationIfPossible()
@@ -124,7 +126,8 @@ public final class SyncEngine {
                 return
             }
         }
-
+        // We only want to create the custom zone in the private database
+        let privateDatabase = DatabaseType.dbPrivate.dataBase()
         privateDatabase.add(modifyOp)
     }
 
@@ -137,22 +140,55 @@ public final class SyncEngine {
 
 /// Chat to the CloudKit API directly
 extension SyncEngine {
-    
-    /// The changes token, for more please reference to https://developer.apple.com/videos/play/wwdc2016/231/
-    var databaseChangeToken: CKServerChangeToken? {
+
+    var privateDatabaseChangeToken: CKServerChangeToken? {
         get {
             /// For the very first time when launching, the token will be nil and the server will be giving everything on the Cloud to client
             /// In other situation just get the unarchive the data object
-            guard let tokenData = UserDefaults.standard.object(forKey: IceCreamKey.databaseChangesTokenKey.value) as? Data else { return nil }
+            guard let tokenData = UserDefaults.standard.object(forKey: IceCreamKey.privateDatabaseChangesTokenKey.value) as? Data else { return nil }
             return NSKeyedUnarchiver.unarchiveObject(with: tokenData) as? CKServerChangeToken
         }
         set {
             guard let n = newValue else {
-                UserDefaults.standard.removeObject(forKey: IceCreamKey.databaseChangesTokenKey.value)
+                UserDefaults.standard.removeObject(forKey: IceCreamKey.privateDatabaseChangesTokenKey.value)
                 return
             }
             let data = NSKeyedArchiver.archivedData(withRootObject: n)
-            UserDefaults.standard.set(data, forKey: IceCreamKey.databaseChangesTokenKey.value)
+            UserDefaults.standard.set(data, forKey: IceCreamKey.privateDatabaseChangesTokenKey.value)
+        }
+    }
+    var sharedDatabaseChangeToken: CKServerChangeToken? {
+        get {
+            /// For the very first time when launching, the token will be nil and the server will be giving everything on the Cloud to client
+            /// In other situation just get the unarchive the data object
+            guard let tokenData = UserDefaults.standard.object(forKey: IceCreamKey.sharedDatabaseChangesTokenKey.value) as? Data else { return nil }
+            return NSKeyedUnarchiver.unarchiveObject(with: tokenData) as? CKServerChangeToken
+        }
+        set {
+            guard let n = newValue else {
+                UserDefaults.standard.removeObject(forKey: IceCreamKey.sharedDatabaseChangesTokenKey.value)
+                return
+            }
+            let data = NSKeyedArchiver.archivedData(withRootObject: n)
+            UserDefaults.standard.set(data, forKey: IceCreamKey.sharedDatabaseChangesTokenKey.value)
+        }
+    }
+
+    /// The changes token, for more please reference to https://developer.apple.com/videos/play/wwdc2016/231/
+    var publicDatabaseChangeToken: CKServerChangeToken? {
+        get {
+            /// For the very first time when launching, the token will be nil and the server will be giving everything on the Cloud to client
+            /// In other situation just get the unarchive the data object
+            guard let tokenData = UserDefaults.standard.object(forKey: IceCreamKey.publicDatabaseChangesTokenKey.value) as? Data else { return nil }
+            return NSKeyedUnarchiver.unarchiveObject(with: tokenData) as? CKServerChangeToken
+        }
+        set {
+            guard let n = newValue else {
+                UserDefaults.standard.removeObject(forKey: IceCreamKey.publicDatabaseChangesTokenKey.value)
+                return
+            }
+            let data = NSKeyedArchiver.archivedData(withRootObject: n)
+            UserDefaults.standard.set(data, forKey: IceCreamKey.publicDatabaseChangesTokenKey.value)
         }
     }
 
@@ -167,45 +203,62 @@ extension SyncEngine {
         }
     }
 
+    private func update(token: CKServerChangeToken?, for databaseType: DatabaseType) {
+        switch databaseType {
+        case .dbPrivate:
+            self.privateDatabaseChangeToken = token
+        case .dbShared:
+            self.sharedDatabaseChangeToken = token
+        }
+    }
+    
     /// Only update the changeToken when fetch process completes
-    private func fetchChangesInDatabase(_ callback: (() -> Void)? = nil) {
+    private func fetchChangesInDatabase(databaseType: DatabaseType, _ callback: (() -> Void)? = nil) {
+        var zoneIDsChanged = [CKRecordZone.ID]()
+        // TODO handle deleted zones
+        var zoneIDsDeleted = [CKRecordZone.ID]()
 
-        let changesOperation = CKFetchDatabaseChangesOperation(previousServerChangeToken: databaseChangeToken)
+        var databaseChangeToken: CKServerChangeToken?
+        switch databaseType {
+        case .dbPrivate:
+            databaseChangeToken = privateDatabaseChangeToken
+        case .dbShared:
+            databaseChangeToken = sharedDatabaseChangeToken
+        }
+        let changesOp = CKFetchDatabaseChangesOperation(previousServerChangeToken: databaseChangeToken)
         
         /// For more, see the source code, it has the detailed explanation
-        changesOperation.fetchAllChanges = true
+        changesOp.fetchAllChanges = true
 
-        changesOperation.changeTokenUpdatedBlock = { [weak self] newToken in
+        changesOp.changeTokenUpdatedBlock = { [weak self] newToken in
             guard let `self` = self else { return }
-            self.databaseChangeToken = newToken
+                `self`.update(token: newToken, for: databaseType)
         }
 
-        /// Cuz we only have one custom zone, so we don't need to store the CKRecordZoneID temporarily
-        /*
-         changesOperation.recordZoneWithIDChangedBlock = { [weak self] zoneID in
-         guard let `self` = self else { return }
-         `self`.changedRecordZoneID = zoneID
-         }
-         */
-        changesOperation.fetchDatabaseChangesCompletionBlock = {
+        changesOp.recordZoneWithIDChangedBlock = { [weak self] zoneID in
+            guard let _ = self else { return }
+            zoneIDsChanged.append(zoneID)
+        }
+ 
+        changesOp.fetchDatabaseChangesCompletionBlock = {
             [weak self]
             newToken, _, error in
             guard let `self` = self else { return }
             switch `self`.errorHandler.resultType(with: error) {
             case .success:
-                `self`.databaseChangeToken = newToken
+                `self`.update(token: newToken, for: databaseType)
                 // Fetch the changes in zone level
-                `self`.fetchChangesInZones(callback)
+                `self`.fetchChangesInZones(databaseType: databaseType, zoneIDs: zoneIDsChanged, callback)
             case .retry(let timeToWait, _):
                 `self`.errorHandler.retryOperationIfPossible(retryAfter: timeToWait, block: {
-                    `self`.fetchChangesInDatabase(callback)
+                    `self`.fetchChangesInZones(databaseType: databaseType, zoneIDs: zoneIDsChanged, callback)
                 })
             case .recoverableError(let reason, _):
                 switch reason {
                 case .changeTokenExpired:
                     /// The previousServerChangeToken value is too old and the client must re-sync from scratch
-                    `self`.databaseChangeToken = nil
-                    `self`.fetchChangesInDatabase(callback)
+                    `self`.update(token: nil, for: databaseType)
+                    `self`.fetchChangesInDatabase(databaseType: databaseType, callback)
                 default:
                     return
                 }
@@ -213,14 +266,21 @@ extension SyncEngine {
                 return
             }
         }
-        privateDatabase.add(changesOperation)
+        databaseType.dataBase().add(changesOp)
     }
 
-    private var zoneIds: [CKRecordZone.ID] {
-        return syncObjects.map { $0.customZoneID }
+    @available(iOS 12.0, *)
+    private var zoneIdOptions: [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneConfiguration] {
+        return syncObjects.reduce([CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneConfiguration]()) { (dict, syncEngine) -> [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneConfiguration] in
+            var dict = dict
+            let zoneChangesConfiguration = CKFetchRecordZoneChangesOperation.ZoneConfiguration()
+            zoneChangesConfiguration.previousServerChangeToken = syncEngine.zoneChangesToken
+            dict[syncEngine.customZoneID] = zoneChangesConfiguration
+            return dict
+        }
     }
-
-    private var zoneIdOptions: [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions] {
+    
+    private var legacyZoneIdOptions: [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions] {
         return syncObjects.reduce([CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions]()) { (dict, syncEngine) -> [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions] in
             var dict = dict
             let zoneChangesOptions = CKFetchRecordZoneChangesOperation.ZoneOptions()
@@ -230,8 +290,14 @@ extension SyncEngine {
         }
     }
 
-    private func fetchChangesInZones(_ callback: (() -> Void)? = nil) {
-        let changesOp = CKFetchRecordZoneChangesOperation(recordZoneIDs: zoneIds, optionsByRecordZoneID: zoneIdOptions)
+    private func fetchChangesInZones(databaseType: DatabaseType, zoneIDs: [CKRecordZone.ID], _ callback: (() -> Void)? = nil) {
+        var changesOp: CKFetchRecordZoneChangesOperation
+        if #available(iOS 12.0, *) {
+            changesOp = CKFetchRecordZoneChangesOperation(recordZoneIDs: zoneIDs, configurationsByRecordZoneID: zoneIdOptions)
+        } else {
+            // Fallback on earlier versions
+            changesOp = CKFetchRecordZoneChangesOperation(recordZoneIDs: zoneIDs, optionsByRecordZoneID: legacyZoneIdOptions)
+        }
         changesOp.fetchAllChanges = true
         
         changesOp.recordZoneChangeTokensUpdatedBlock = { [weak self] zoneId, token, _ in
@@ -245,7 +311,7 @@ extension SyncEngine {
             /// Handle the record:
             guard let `self` = self else { return }
             guard let syncObject = `self`.syncObjects.first(where: { $0.recordType == record.recordType }) else { return }
-            syncObject.add(record: record)
+            syncObject.add(databaseType: databaseType, record: record)
         }
 
         changesOp.recordWithIDWasDeletedBlock = { [weak self] recordId, _ in
@@ -254,17 +320,16 @@ extension SyncEngine {
             syncObject.delete(recordID: recordId)
         }
 
-        changesOp.recordZoneFetchCompletionBlock = { [weak self](zoneId ,token, _, _, error) in
+        changesOp.recordZoneFetchCompletionBlock = { [weak self](zoneId , token, clientChangeTokenData, isMoreComing, error) in
             guard let `self` = self else { return }
             switch `self`.errorHandler.resultType(with: error) {
             case .success:
                 guard let syncObject = `self`.syncObjects.first(where: { $0.customZoneID == zoneId }) else { return }
                 syncObject.zoneChangesToken = token
                 callback?()
-                print("Sync successfully!")
             case .retry(let timeToWait, _):
                 `self`.errorHandler.retryOperationIfPossible(retryAfter: timeToWait, block: {
-                    `self`.fetchChangesInZones(callback)
+                    `self`.fetchChangesInZones(databaseType: databaseType, zoneIDs: zoneIDs, callback)
                 })
             case .recoverableError(let reason, _):
                 switch reason {
@@ -272,7 +337,7 @@ extension SyncEngine {
                     /// The previousServerChangeToken value is too old and the client must re-sync from scratch
                     guard let syncObject = `self`.syncObjects.first(where: { $0.customZoneID == zoneId }) else { return }
                     syncObject.zoneChangesToken = nil
-                    `self`.fetchChangesInZones(callback)
+                    `self`.fetchChangesInZones(databaseType: databaseType, zoneIDs: zoneIDs, callback)
                 default:
                     return
                 }
@@ -280,33 +345,35 @@ extension SyncEngine {
                 return
             }
         }
-
-        privateDatabase.add(changesOp)
+        databaseType.dataBase().add(changesOp)
     }
 
     fileprivate func createDatabaseSubscription() {
         // The direct below is the subscribe way that Apple suggests in CloudKit Best Practices(https://developer.apple.com/videos/play/wwdc2016/231/) , but it doesn't work here in my place.
 
-        let subscription = CKDatabaseSubscription(subscriptionID: IceCreamConstant.cloudKitSubscriptionID)
-
-        let notificationInfo = CKSubscription.NotificationInfo()
-        notificationInfo.shouldSendContentAvailable = true // Silent Push
-
-        subscription.notificationInfo = notificationInfo
-
-        let createOp = CKModifySubscriptionsOperation(subscriptionsToSave: [subscription], subscriptionIDsToDelete: [])
-        createOp.modifySubscriptionsCompletionBlock = { _, _, error in
-            guard error == nil else { return }
-            self.subscriptionIsLocallyCached = true
+        for database in [DatabaseType.dbPrivate.dataBase(), DatabaseType.dbShared.dataBase()] {
+            let subscription = CKDatabaseSubscription(subscriptionID: IceCreamConstant.cloudKitSubscriptionID)
+            
+            let notificationInfo = CKSubscription.NotificationInfo()
+            notificationInfo.shouldSendContentAvailable = true // Silent Push
+            
+            subscription.notificationInfo = notificationInfo
+            
+            let createOp = CKModifySubscriptionsOperation(subscriptionsToSave: [subscription], subscriptionIDsToDelete: [])
+            createOp.modifySubscriptionsCompletionBlock = { _, _, error in
+                guard error == nil else { return }
+                self.subscriptionIsLocallyCached = true
+            }
+            createOp.qualityOfService = .utility
+            database.add(createOp)
         }
-        createOp.qualityOfService = .utility
-        privateDatabase.add(createOp)
     }
 
     fileprivate func startObservingRemoteChanges() {
         NotificationCenter.default.addObserver(forName: Notifications.cloudKitDataDidChangeRemotely.name, object: nil, queue: OperationQueue.main, using: { [weak self](_) in
             guard let `self` = self else { return }
-            `self`.fetchChangesInDatabase()
+            `self`.fetchChangesInDatabase(databaseType: .dbPrivate)
+            `self`.fetchChangesInDatabase(databaseType: .dbShared)
         })
     }
 }
@@ -344,27 +411,27 @@ extension SyncEngine {
     /// Sync local data to CloudKit
     /// For more about the savePolicy: https://developer.apple.com/documentation/cloudkit/ckrecordsavepolicy
     public func syncRecordsToCloudKit(recordsToStore: [CKRecord], recordIDsToDelete: [CKRecord.ID], completion: ((Error?) -> ())? = nil) {
-        let modifyOpe = CKModifyRecordsOperation(recordsToSave: recordsToStore, recordIDsToDelete: recordIDsToDelete)
+        let modifyOp = CKModifyRecordsOperation(recordsToSave: recordsToStore, recordIDsToDelete: recordIDsToDelete)
         
         if #available(iOS 11.0, *) {
             let config = CKOperation.Configuration()
             config.isLongLived = true
-            modifyOpe.configuration = config
+            modifyOp.configuration = config
         } else {
             // Fallback on earlier versions
-            modifyOpe.isLongLived = true
+            modifyOp.isLongLived = true
         }
         
         // We use .changedKeys savePolicy to do unlocked changes here cause my app is contentious and off-line first
         // Apple suggests using .ifServerRecordUnchanged save policy
         // For more, see Advanced CloudKit(https://developer.apple.com/videos/play/wwdc2014/231/)
-        modifyOpe.savePolicy = .changedKeys
+        modifyOp.savePolicy = .changedKeys
         
         // To avoid CKError.partialFailure, make the operation atomic (if one record fails to get modified, they all fail)
         // If you want to handle partial failures, set .isAtomic to false and implement CKOperationResultType .fail(reason: .partialFailure) where appropriate
-        modifyOpe.isAtomic = true
+        modifyOp.isAtomic = true
         
-        modifyOpe.modifyRecordsCompletionBlock = {
+        modifyOp.modifyRecordsCompletionBlock = {
             [weak self]
             (_, _, error) in
             
@@ -396,13 +463,13 @@ extension SyncEngine {
                 return
             }
         }
-        
-        privateDatabase.add(modifyOpe)
+        DatabaseType.dbPrivate.dataBase().add(modifyOp)
     }
     
     // Manually sync data with CloudKit
     public func sync() {
-        fetchChangesInDatabase()
+        fetchChangesInDatabase(databaseType: .dbPrivate)
+        fetchChangesInDatabase(databaseType: .dbShared)
     }
 }
 

--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -91,7 +91,7 @@ public final class SyncEngine {
                     }
                 }
                 
-                NotificationCenter.default.addObserver(self, selector: #selector(`self`.cleanUp), name: .UIApplicationWillTerminate, object: nil)
+                NotificationCenter.default.addObserver(self, selector: #selector(`self`.cleanUp), name: UIApplication.willTerminateNotification, object: nil)
                 
                 /// 3. Create the subscription to the CloudKit database
                 if `self`.subscriptionIsLocallyCached { return }
@@ -216,14 +216,14 @@ extension SyncEngine {
         privateDatabase.add(changesOperation)
     }
 
-    private var zoneIds: [CKRecordZoneID] {
+    private var zoneIds: [CKRecordZone.ID] {
         return syncObjects.map { $0.customZoneID }
     }
 
-    private var zoneIdOptions: [CKRecordZoneID: CKFetchRecordZoneChangesOptions] {
-        return syncObjects.reduce([CKRecordZoneID: CKFetchRecordZoneChangesOptions]()) { (dict, syncEngine) -> [CKRecordZoneID: CKFetchRecordZoneChangesOptions] in
+    private var zoneIdOptions: [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions] {
+        return syncObjects.reduce([CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions]()) { (dict, syncEngine) -> [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneOptions] in
             var dict = dict
-            let zoneChangesOptions = CKFetchRecordZoneChangesOptions()
+            let zoneChangesOptions = CKFetchRecordZoneChangesOperation.ZoneOptions()
             zoneChangesOptions.previousServerChangeToken = syncEngine.zoneChangesToken
             dict[syncEngine.customZoneID] = zoneChangesOptions
             return dict
@@ -289,7 +289,7 @@ extension SyncEngine {
 
         let subscription = CKDatabaseSubscription(subscriptionID: IceCreamConstant.cloudKitSubscriptionID)
 
-        let notificationInfo = CKNotificationInfo()
+        let notificationInfo = CKSubscription.NotificationInfo()
         notificationInfo.shouldSendContentAvailable = true // Silent Push
 
         subscription.notificationInfo = notificationInfo
@@ -343,11 +343,11 @@ extension SyncEngine {
 extension SyncEngine {
     /// Sync local data to CloudKit
     /// For more about the savePolicy: https://developer.apple.com/documentation/cloudkit/ckrecordsavepolicy
-    public func syncRecordsToCloudKit(recordsToStore: [CKRecord], recordIDsToDelete: [CKRecordID], completion: ((Error?) -> ())? = nil) {
+    public func syncRecordsToCloudKit(recordsToStore: [CKRecord], recordIDsToDelete: [CKRecord.ID], completion: ((Error?) -> ())? = nil) {
         let modifyOpe = CKModifyRecordsOperation(recordsToSave: recordsToStore, recordIDsToDelete: recordIDsToDelete)
         
         if #available(iOS 11.0, *) {
-            let config = CKOperationConfiguration()
+            let config = CKOperation.Configuration()
             config.isLongLived = true
             modifyOpe.configuration = config
         } else {

--- a/IceCream/Classes/SyncObject.swift
+++ b/IceCream/Classes/SyncObject.swift
@@ -23,7 +23,7 @@ public final class SyncObject<T> where T: Object & CKRecordConvertible & CKRecor
     
     private let errorHandler = ErrorHandler()
     
-    public var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecordID]) -> ())?
+    public var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecord.ID]) -> ())?
     
     public init() {}
 }
@@ -36,7 +36,7 @@ extension SyncObject: Syncable {
         return T.recordType
     }
     
-    public var customZoneID: CKRecordZoneID {
+    public var customZoneID: CKRecordZone.ID {
         return T.customZoneID
     }
     
@@ -89,7 +89,7 @@ extension SyncObject: Syncable {
         }
     }
     
-    public func delete(recordID: CKRecordID) {
+    public func delete(recordID: CKRecord.ID) {
         DispatchQueue.main.async {
             let realm = try! Realm()
             guard let object = realm.object(ofType: T.self, forPrimaryKey: recordID.recordName) else {

--- a/IceCream/Classes/SyncObject.swift
+++ b/IceCream/Classes/SyncObject.swift
@@ -68,12 +68,13 @@ extension SyncObject: Syncable {
         }
     }
     
-    public func add(record: CKRecord) {
-        guard let object = T().parseFromRecord(record: record) else {
+    public func add(databaseType: DatabaseType, record: CKRecord) {
+        guard var object = T().parseFromRecord(record: record) else {
             print("There is something wrong with the converson from cloud record to local object")
             return
         }
-        
+        object.databaseType = databaseType
+
         DispatchQueue.main.async {
             let realm = try! Realm()
             
@@ -129,7 +130,7 @@ extension SyncObject: Syncable {
                 
                 guard objectsToStore.count > 0 || objectsToDelete.count > 0 else { return }
                 
-                let recordsToStore = objectsToStore.map{ $0.record }
+                let recordsToStore = objectsToStore.filter{ $0.databaseType == .dbPrivate }.map{ $0.record }
                 let recordIDsToDelete = objectsToDelete.map{ $0.recordID }
                 
                 `self`.pipeToEngine?(recordsToStore, recordIDsToDelete)

--- a/IceCream/Classes/Syncable.swift
+++ b/IceCream/Classes/Syncable.swift
@@ -14,7 +14,7 @@ public protocol Syncable: class {
     
     /// CKRecordZone related
     var recordType: String { get }
-    var customZoneID: CKRecordZoneID { get }
+    var customZoneID: CKRecordZone.ID { get }
     
     /// Local storage
     var zoneChangesToken: CKServerChangeToken? { get set }
@@ -24,8 +24,8 @@ public protocol Syncable: class {
     func registerLocalDatabase()
     func cleanUp()
     func add(record: CKRecord)
-    func delete(recordID: CKRecordID)
+    func delete(recordID: CKRecord.ID)
     
     /// Callback
-    var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecordID]) -> ())? { get set }
+    var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecord.ID]) -> ())? { get set }
 }

--- a/IceCream/Classes/Syncable.swift
+++ b/IceCream/Classes/Syncable.swift
@@ -23,9 +23,12 @@ public protocol Syncable: class {
     /// Realm Database related
     func registerLocalDatabase()
     func cleanUp()
-    func add(record: CKRecord)
+    func add(databaseType: DatabaseType, record: CKRecord)
     func delete(recordID: CKRecord.ID)
-    
-    /// Callback
+ 
+    ///
+    /// Upon observing changes originating locally, send the changes to CloudKit
+    /// - Parameters:
+    ///   - recordsToStore: An array of all
     var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecord.ID]) -> ())? { get set }
 }


### PR DESCRIPTION
This resolves #4 and provides basic sync functionality with the shared database. 
There are a few considerations here that are worth discussing. 

1. The objects that conform to `CKRecordRecoverable` now require a `databaseType` attribute so this effectively is an API breaking change.
2. Many of the CloudKit operations are now database specific and as such required some API changes. 
3. We `@available`'ed the methods for zone change updates for backwards compatibility.
4. This is built off of @sprynmr's changes in #72 so it may make sense to either merge that PR first, or view this PR through a branch diff tool of your choice. As the sharing is all in one commit, you might look here: https://github.com/caiyue1993/IceCream/commit/b128ba4ca9a09be430f987bec9d8de65d3b47767
5. This PR does not cover accepting the share though `internal func application(_ application: UIApplication, userDidAcceptCloudKitShareWith cloudKitShareMetadata: CKShare.Metadata)`
 