### PR TITLE
Retry when partial failure error occurs

### DIFF
--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -365,6 +365,15 @@ extension SyncEngine {
                 for chunk in chunkedRecords {
                     `self`.syncRecordsToCloudKit(recordsToStore: chunk, recordIDsToDelete: recordIDsToDelete, completion: completion)
                 }
+            case .recoverableError(let reason, _):
+                switch reason {
+                case .partialFailure:
+                    `self`.errorHandler.retryOperationIfPossible(retryAfter: IceCreamConstant.defaultRetryTime) {
+                        `self`.syncRecordsToCloudKit(recordsToStore: recordsToStore, recordIDsToDelete: recordIDsToDelete, completion: completion)
+                    }
+                default:
+                    return
+                }
             default:
                 return
             }
@@ -404,5 +413,6 @@ public enum IceCreamKey: String {
 /// The right way is remove old subscription first and then save new subscription.
 public struct IceCreamConstant {
     public static let cloudKitSubscriptionID = "private_changes"
+    static let defaultRetryTime: Double = 2
 }
 


### PR DESCRIPTION
Hi again!

 I'm getting a weird error the first time my app pushes some objects to CloudKit. Its uploading 2 changes, one of them fails so I get a partial error (yep, even with isAtomic on, no changes for that on my side). 

This change fixes it setting a default retry when that error occurs. I'm not sure if this is the best way to handle it, just wanted to get rid of the error.