### PR TITLE
Add new no-Optional property cause crash.

### DIFF
--- a/IceCream/Classes/CKRecordRecoverable.swift
+++ b/IceCream/Classes/CKRecordRecoverable.swift
@@ -42,7 +42,9 @@ extension CKRecordRecoverable where Self: Object {
             default:
                 print("Other types will be supported in the future.")
             }
-            o.setValue(recordValue, forKey: prop.name)
+            if recordValue != nil || (recordValue == nil && prop.isOptional) {
+                o.setValue(recordValue, forKey: prop.name)
+            }
         }
         return o
     }


### PR DESCRIPTION

```
// before
class A: Object {
    @objc dynamic var id: String = UUID().uuidString
}
// after
class A: Object {
    @objc dynamic var id: String = UUID().uuidString
    @objc dynamic var updatedAt: Date = Date()
}
```
Two Device. iPhone and iPad
using iPhone nothing error. and upload some record to cloudKit.
using iPad  error.  I get a crash. A.updatedAt.setter error.

I think `updatedAt` value  in CloudKit is `nil`

```
// CKRecordRecoverable.swift parseFromRecord
recordValue = record.value(forKey: prop.name) as? Date // updatedAt is nil
o.setValue(recordValue, forKey: prop.name) // prop is no-optional. setter will get a error
```
so I try blow code and no error.
```
     if recordValue != nil || (recordValue == nil && prop.isOptional) {
                o.setValue(recordValue, forKey: prop.name)
            }
```