### PR TITLE
Add support for Lists of basic types and avoid duplicating CreamAssets

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "realm/realm-cocoa" "v3.7.6"
+github "realm/realm-cocoa" "v3.11.1"

--- a/IceCream.podspec
+++ b/IceCream.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'IceCream'
-  s.version          = '1.7.1'
+  s.version          = '1.7.2'
   s.summary          = 'Sync Realm with CloudKit'
   s.description      = <<-DESC
   Sync Realm Database with CloudKit, written in Swift. It works just like magic.

--- a/IceCream.podspec
+++ b/IceCream.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'IceCream'
-  s.version          = '1.7.0'
+  s.version          = '1.7.1'
   s.summary          = 'Sync Realm with CloudKit'
   s.description      = <<-DESC
   Sync Realm Database with CloudKit, written in Swift. It works just like magic.

--- a/IceCream.xcodeproj/xcshareddata/xcschemes/IceCream-tvOS.xcscheme
+++ b/IceCream.xcodeproj/xcshareddata/xcschemes/IceCream-tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6747814E213BE66C005C132B"
-               BuildableName = "IceCream_tvOS.framework"
+               BuildableName = "IceCream.framework"
                BlueprintName = "IceCream-tvOS"
                ReferencedContainer = "container:IceCream.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6747814E213BE66C005C132B"
-            BuildableName = "IceCream_tvOS.framework"
+            BuildableName = "IceCream.framework"
             BlueprintName = "IceCream-tvOS"
             ReferencedContainer = "container:IceCream.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6747814E213BE66C005C132B"
-            BuildableName = "IceCream_tvOS.framework"
+            BuildableName = "IceCream.framework"
             BlueprintName = "IceCream-tvOS"
             ReferencedContainer = "container:IceCream.xcodeproj">
          </BuildableReference>

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -54,15 +54,53 @@ extension CKRecordConvertible where Self: Object {
         let r = CKRecord(recordType: Self.recordType, recordID: recordID)
         let properties = objectSchema.properties
         for prop in properties {
+            
+            let item = self[prop.name]
+            
             switch prop.type {
-            case .int, .string, .bool, .date, .float, .double, .data:
-                r[prop.name] = self[prop.name] as? CKRecordValue
+            case .int, .string, .bool, .float, .double, .data:
+                if prop.isArray {
+                    switch prop.type {
+                    case .int:
+                        guard let list = item as? List<Int> else { break }
+                        let array = Array(list)
+                        r[prop.name] = array as CKRecordValue
+                    case .string:
+                        guard let list = item as? List<String> else { break }
+                        let array = Array(list)
+                        r[prop.name] = array as CKRecordValue
+                    case .bool:
+                        guard let list = item as? List<Bool> else { break }
+                        let array = Array(list)
+                        r[prop.name] = array as CKRecordValue
+                    case .float:
+                        guard let list = item as? List<Float> else { break }
+                        let array = Array(list)
+                        r[prop.name] = array as CKRecordValue
+                    case .double:
+                        guard let list = item as? List<Double> else { break }
+                        let array = Array(list)
+                        r[prop.name] = array as CKRecordValue
+                    case .data:
+                        guard let list = item as? List<Data> else { break }
+                        let array = Array(list)
+                        r[prop.name] = array as CKRecordValue
+                    default:
+                        break
+                    }
+                    
+                    break
+                } else {
+                    r[prop.name] = item as? CKRecordValue
+                }
+            case .date:
+                r[prop.name] = item as? CKRecordValue
             case .object:
                 guard let objectName = prop.objectClassName else { break }
                 // If object is CreamAsset, set record with its wrapped CKAsset value
-                if objectName == CreamAsset.className(), let creamAsset = self[prop.name] as? CreamAsset {
+                if objectName == CreamAsset.className(), let creamAsset = item as? CreamAsset {
                     r[prop.name] = creamAsset.asset
-                } else if let owner = self[prop.name] as? CKRecordConvertible {
+                } else if let owner = item as? CKRecordConvertible {
                     // Handle to-one relationship: https://realm.io/docs/swift/latest/#many-to-one
                     // So the owner Object has to conform to CKRecordConvertible protocol
                     r[prop.name] = CKRecord.Reference(recordID: owner.recordID, action: .none)

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -60,33 +60,27 @@ extension CKRecordConvertible where Self: Object {
             if prop.isArray {
                 switch prop.type {
                 case .int:
-                    guard let list = item as? List<Int>,
-                        !list.isEmpty else { break }
+                    guard let list = item as? List<Int>, !list.isEmpty else { break }
                     let array = Array(list)
                     r[prop.name] = array as CKRecordValue
                 case .string:
-                    guard let list = item as? List<String>,
-                        !list.isEmpty  else { break }
+                    guard let list = item as? List<String>, !list.isEmpty else { break }
                     let array = Array(list)
                     r[prop.name] = array as CKRecordValue
                 case .bool:
-                    guard let list = item as? List<Bool>,
-                        !list.isEmpty  else { break }
+                    guard let list = item as? List<Bool>, !list.isEmpty else { break }
                     let array = Array(list)
                     r[prop.name] = array as CKRecordValue
                 case .float:
-                    guard let list = item as? List<Float>,
-                        !list.isEmpty  else { break }
+                    guard let list = item as? List<Float>, !list.isEmpty else { break }
                     let array = Array(list)
                     r[prop.name] = array as CKRecordValue
                 case .double:
-                    guard let list = item as? List<Double>,
-                        !list.isEmpty  else { break }
+                    guard let list = item as? List<Double>, !list.isEmpty else { break }
                     let array = Array(list)
                     r[prop.name] = array as CKRecordValue
                 case .data:
-                    guard let list = item as? List<Data>,
-                        !list.isEmpty  else { break }
+                    guard let list = item as? List<Data>, !list.isEmpty else { break }
                     let array = Array(list)
                     r[prop.name] = array as CKRecordValue
                 case .date:

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -57,49 +57,51 @@ extension CKRecordConvertible where Self: Object {
             
             let item = self[prop.name]
             
-            switch prop.type {
-            case .int, .string, .bool, .float, .double, .data:
-                if prop.isArray {
-                    switch prop.type {
-                    case .int:
-                        guard let list = item as? List<Int>,
-                         !list.isEmpty else { break }
-                        let array = Array(list)
-                        r[prop.name] = array as CKRecordValue
-                    case .string:
-                        guard let list = item as? List<String>,
-                            !list.isEmpty  else { break }
-                        let array = Array(list)
-                        r[prop.name] = array as CKRecordValue
-                    case .bool:
-                        guard let list = item as? List<Bool>,
-                            !list.isEmpty  else { break }
-                        let array = Array(list)
-                        r[prop.name] = array as CKRecordValue
-                    case .float:
-                        guard let list = item as? List<Float>,
-                            !list.isEmpty  else { break }
-                        let array = Array(list)
-                        r[prop.name] = array as CKRecordValue
-                    case .double:
-                        guard let list = item as? List<Double>,
-                            !list.isEmpty  else { break }
-                        let array = Array(list)
-                        r[prop.name] = array as CKRecordValue
-                    case .data:
-                        guard let list = item as? List<Data>,
-                            !list.isEmpty  else { break }
-                        let array = Array(list)
-                        r[prop.name] = array as CKRecordValue
-                    default:
-                        break
-                    }
-                    
+            if prop.isArray {
+                switch prop.type {
+                case .int:
+                    guard let list = item as? List<Int>,
+                        !list.isEmpty else { break }
+                    let array = Array(list)
+                    r[prop.name] = array as CKRecordValue
+                case .string:
+                    guard let list = item as? List<String>,
+                        !list.isEmpty  else { break }
+                    let array = Array(list)
+                    r[prop.name] = array as CKRecordValue
+                case .bool:
+                    guard let list = item as? List<Bool>,
+                        !list.isEmpty  else { break }
+                    let array = Array(list)
+                    r[prop.name] = array as CKRecordValue
+                case .float:
+                    guard let list = item as? List<Float>,
+                        !list.isEmpty  else { break }
+                    let array = Array(list)
+                    r[prop.name] = array as CKRecordValue
+                case .double:
+                    guard let list = item as? List<Double>,
+                        !list.isEmpty  else { break }
+                    let array = Array(list)
+                    r[prop.name] = array as CKRecordValue
+                case .data:
+                    guard let list = item as? List<Data>,
+                        !list.isEmpty  else { break }
+                    let array = Array(list)
+                    r[prop.name] = array as CKRecordValue
+                case .date:
+                    guard let list = item as? List<Date>, !list.isEmpty else { break }
+                    let array = Array(list)
+                    r[prop.name] = array as CKRecordValue
+                default:
                     break
-                } else {
-                    r[prop.name] = item as? CKRecordValue
+                    /// Other inner types of List is not supported yet
                 }
-            case .date:
+                continue
+            }
+            
+            switch prop.type {
+            case .int, .string, .bool, .date, .float, .double, .data:
                 r[prop.name] = item as? CKRecordValue
             case .object:
                 guard let objectName = prop.objectClassName else { break }

--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -62,27 +62,33 @@ extension CKRecordConvertible where Self: Object {
                 if prop.isArray {
                     switch prop.type {
                     case .int:
-                        guard let list = item as? List<Int> else { break }
+                        guard let list = item as? List<Int>,
+                         !list.isEmpty else { break }
                         let array = Array(list)
                         r[prop.name] = array as CKRecordValue
                     case .string:
-                        guard let list = item as? List<String> else { break }
+                        guard let list = item as? List<String>,
+                            !list.isEmpty  else { break }
                         let array = Array(list)
                         r[prop.name] = array as CKRecordValue
                     case .bool:
-                        guard let list = item as? List<Bool> else { break }
+                        guard let list = item as? List<Bool>,
+                            !list.isEmpty  else { break }
                         let array = Array(list)
                         r[prop.name] = array as CKRecordValue
                     case .float:
-                        guard let list = item as? List<Float> else { break }
+                        guard let list = item as? List<Float>,
+                            !list.isEmpty  else { break }
                         let array = Array(list)
                         r[prop.name] = array as CKRecordValue
                     case .double:
-                        guard let list = item as? List<Double> else { break }
+                        guard let list = item as? List<Double>,
+                            !list.isEmpty  else { break }
                         let array = Array(list)
                         r[prop.name] = array as CKRecordValue
                     case .data:
-                        guard let list = item as? List<Data> else { break }
+                        guard let list = item as? List<Data>,
+                            !list.isEmpty  else { break }
                         let array = Array(list)
                         r[prop.name] = array as CKRecordValue
                     default:

--- a/IceCream/Classes/CKRecordRecoverable.swift
+++ b/IceCream/Classes/CKRecordRecoverable.swift
@@ -21,32 +21,32 @@ extension CKRecordRecoverable where Self: Object {
             if prop.isArray {
                 switch prop.type {
                 case .int:
-                    let value = record.value(forKey: prop.name) as? [Int]
+                    guard let value = record.value(forKey: prop.name) as? [Int] else { break }
                     let list = List<Int>()
                     list.append(objectsIn: value)
                     recordValue = list
                 case .string:
-                    let value = record.value(forKey: prop.name) as? [String]
+                    guard let value = record.value(forKey: prop.name) as? [String] else { break }
                     let list = List<String>()
                     list.append(objectsIn: value)
                     recordValue = list
                 case .bool:
-                    let value = record.value(forKey: prop.name) as? [Bool]
+                    guard let value = record.value(forKey: prop.name) as? [Bool] else { break }
                     let list = List<Bool>()
                     list.append(objectsIn: value)
                     recordValue = list
                 case .float:
-                    let value = record.value(forKey: prop.name) as? [Float]
+                    guard let value = record.value(forKey: prop.name) as? [Float] else { break }
                     let list = List<Float>()
                     list.append(objectsIn: value)
                     recordValue = list
                 case .double:
-                    let value = record.value(forKey: prop.name) as? [Double]
+                    guard let value = record.value(forKey: prop.name) as? [Double] else { break }
                     let list = List<Double>()
                     list.append(objectsIn: value)
                     recordValue = list
                 case .data:
-                    let value = record.value(forKey: prop.name) as? [Data]
+                    guard let value = record.value(forKey: prop.name) as? [Data] else { break }
                     let list = List<Data>()
                     list.append(objectsIn: value)
                     recordValue = list

--- a/IceCream/Classes/CKRecordRecoverable.swift
+++ b/IceCream/Classes/CKRecordRecoverable.swift
@@ -17,6 +17,45 @@ extension CKRecordRecoverable where Self: Object {
         let o = Self()
         for prop in o.objectSchema.properties {
             var recordValue: Any?
+            
+            if prop.isArray {
+                switch prop.type {
+                case .int:
+                    let value = record.value(forKey: prop.name) as? [Int]
+                    let list = List<Int>()
+                    list.append(objectsIn: value)
+                    recordValue = list
+                case .string:
+                    let value = record.value(forKey: prop.name) as? [String]
+                    let list = List<String>()
+                    list.append(objectsIn: value)
+                    recordValue = list
+                case .bool:
+                    let value = record.value(forKey: prop.name) as? [Bool]
+                    let list = List<Bool>()
+                    list.append(objectsIn: value)
+                    recordValue = list
+                case .float:
+                    let value = record.value(forKey: prop.name) as? [Float]
+                    let list = List<Float>()
+                    list.append(objectsIn: value)
+                    recordValue = list
+                case .double:
+                    let value = record.value(forKey: prop.name) as? [Double]
+                    let list = List<Double>()
+                    list.append(objectsIn: value)
+                    recordValue = list
+                case .data:
+                    let value = record.value(forKey: prop.name) as? [Data]
+                    let list = List<Data>()
+                    list.append(objectsIn: value)
+                    recordValue = list
+                default:
+                    break
+                }
+                break
+            }
+            
             switch prop.type {
             case .int:
                 recordValue = record.value(forKey: prop.name) as? Int

--- a/IceCream/Classes/CKRecordRecoverable.swift
+++ b/IceCream/Classes/CKRecordRecoverable.swift
@@ -53,7 +53,8 @@ extension CKRecordRecoverable where Self: Object {
                 default:
                     break
                 }
-                break
+                o.setValue(recordValue, forKey: prop.name)
+                continue
             }
             
             switch prop.type {

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -70,7 +70,7 @@ public class CreamAsset: Object {
     }
     
     /// An empty CreamAsset, useful if you're not storing anything
-    static var empty: CreamAsset {
+    public static var empty: CreamAsset {
         return CreamAsset(empty: true)
     }
 

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -23,18 +23,12 @@ public class CreamAsset: Object {
     override public static func ignoredProperties() -> [String] {
         return ["data", "filePath"]
     }
-    
-    private convenience init(empty: Bool) {
-        self.init()
-        self.data = nil
-    }
 
-    private convenience init(objectID: String, propName: String, data: Data, force: Bool = false) {
+    private convenience init(objectID: String, propName: String, data: Data) {
         self.init()
         self.data = data
         self.uniqueFileName = "\(objectID)_\(propName)"
-        
-        save(data: data, to: uniqueFileName, force: force)
+        save(data: data, to: uniqueFileName)
     }
 
     private convenience init?(objectID: String, propName: String, url: URL) {
@@ -53,9 +47,8 @@ public class CreamAsset: Object {
         return CreamAsset.creamAssetDefaultURL().appendingPathComponent(uniqueFileName)
     }
 
-    private func save(data: Data, to path: String, force: Bool = false) {
+    func save(data: Data, to path: String) {
         let url = CreamAsset.creamAssetDefaultURL().appendingPathComponent(path)
-        if FileManager.default.fileExists(atPath: url.path), !force { return }
         do {
             try data.write(to: url)
         } catch {
@@ -68,11 +61,6 @@ public class CreamAsset: Object {
             return CKAsset(fileURL: filePath)
         }
     }
-    
-    /// An empty CreamAsset, useful if you're not storing anything
-    public static var empty: CreamAsset {
-        return CreamAsset(empty: true)
-    }
 
     /// Parses a CKRecord and CKAsset back into a CreamAsset
     ///
@@ -84,21 +72,6 @@ public class CreamAsset: Object {
     static func parse(from propName: String, record: CKRecord, asset: CKAsset) -> CreamAsset? {
         return CreamAsset(objectID: record.recordID.recordName, propName: propName, url: asset.fileURL)
     }
-    
-    /// Creates a new CreamAsset for the given object id with Data
-    ///
-    /// - Parameters:
-    ///   - objectID: The object ID (key property of the Realm object) the asset will live on
-    ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
-    ///   - data: The file data
-    ///   - force: Whether to force a new save, even if the file already exists
-    /// - Returns: A CreamAsset if it was successful
-    public static func create(objectID: String, propName: String, data: Data, force: Bool = false) -> CreamAsset? {
-        return CreamAsset(objectID: objectID,
-                          propName: propName,
-                          data: data,
-                          force: force)
-    }
 
     /// Creates a new CreamAsset for the given object with Data
     ///
@@ -106,13 +79,11 @@ public class CreamAsset: Object {
     ///   - object: The object the asset will live on
     ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
     ///   - data: The file data
-    ///   - force: Whether to force a new save, even if the file already exists
     /// - Returns: A CreamAsset if it was successful
-    public static func create(object: CKRecordConvertible, propName: String, data: Data, force: Bool = false) -> CreamAsset? {
+    public static func create(object: CKRecordConvertible, propName: String, data: Data) -> CreamAsset? {
         return CreamAsset(objectID: object.recordID.recordName,
                           propName: propName,
-                          data: data,
-                          force: force)
+                          data: data)
     }
 
     /// Creates a new CreamAsset for the given object with a URL

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -23,6 +23,11 @@ public class CreamAsset: Object {
     override public static func ignoredProperties() -> [String] {
         return ["data", "filePath"]
     }
+    
+    private convenience init(empty: Bool) {
+        self.init()
+        self.data = nil
+    }
 
     private convenience init(objectID: String, propName: String, data: Data, force: Bool) {
         self.init()
@@ -62,6 +67,11 @@ public class CreamAsset: Object {
         get {
             return CKAsset(fileURL: filePath)
         }
+    }
+    
+    /// An empty CreamAsset, useful if you're not storing anything
+    static var empty: CreamAsset {
+        return CreamAsset(empty: true)
     }
 
     /// Parses a CKRecord and CKAsset back into a CreamAsset

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -53,9 +53,9 @@ public class CreamAsset: Object {
         return CreamAsset.creamAssetDefaultURL().appendingPathComponent(uniqueFileName)
     }
 
-    func save(data: Data, to path: String, force: Bool = false) {
+    private func save(data: Data, to path: String, force: Bool = false) {
         let url = CreamAsset.creamAssetDefaultURL().appendingPathComponent(path)
-        if let existingData = try? Data(contentsOf: url), !force { return }
+        if FileManager.default.fileExists(atPath: url.path), !force { return }
         do {
             try data.write(to: url)
         } catch {

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -29,7 +29,7 @@ public class CreamAsset: Object {
         self.data = nil
     }
 
-    private convenience init(objectID: String, propName: String, data: Data, force: Bool) {
+    private convenience init(objectID: String, propName: String, data: Data, force: Bool = false) {
         self.init()
         self.data = data
         self.uniqueFileName = "\(objectID)_\(propName)"
@@ -53,9 +53,9 @@ public class CreamAsset: Object {
         return CreamAsset.creamAssetDefaultURL().appendingPathComponent(uniqueFileName)
     }
 
-    func save(data: Data, to path: String, force: Bool) {
+    func save(data: Data, to path: String, force: Bool = false) {
         let url = CreamAsset.creamAssetDefaultURL().appendingPathComponent(path)
-        guard Data(contentsOf: url) == nil || force else { return }
+        guard try? Data(contentsOf: url) == nil || force else { return }
         do {
             try data.write(to: url)
         } catch {
@@ -93,7 +93,7 @@ public class CreamAsset: Object {
     ///   - data: The file data
     ///   - force: Whether to force a new save, even if the file already exists
     /// - Returns: A CreamAsset if it was successful
-    public static func create(objectID: String, propName: String, data: Data, force: Bool) -> CreamAsset? {
+    public static func create(objectID: String, propName: String, data: Data, force: Bool = false) -> CreamAsset? {
         return CreamAsset(objectID: objectID,
                           propName: propName,
                           data: data,
@@ -108,7 +108,7 @@ public class CreamAsset: Object {
     ///   - data: The file data
     ///   - force: Whether to force a new save, even if the file already exists
     /// - Returns: A CreamAsset if it was successful
-    public static func create(object: CKRecordConvertible, propName: String, data: Data, force: Bool) -> CreamAsset? {
+    public static func create(object: CKRecordConvertible, propName: String, data: Data, force: Bool = false) -> CreamAsset? {
         return CreamAsset(objectID: object.recordID.recordName,
                           propName: propName,
                           data: data,

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -72,6 +72,19 @@ public class CreamAsset: Object {
     static func parse(from propName: String, record: CKRecord, asset: CKAsset) -> CreamAsset? {
         return CreamAsset(objectID: record.recordID.recordName, propName: propName, url: asset.fileURL)
     }
+    
+    /// Creates a new CreamAsset for the given object id with Data
+    ///
+    /// - Parameters:
+    ///   - objectID: The object ID (key property of the Realm object) the asset will live on
+    ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
+    ///   - data: The file data
+    /// - Returns: A CreamAsset if it was successful
+    public static func create(objectID: String, propName: String, data: Data) -> CreamAsset? {
+        return CreamAsset(objectID: objectID,
+                          propName: propName,
+                          data: data)
+    }
 
     /// Creates a new CreamAsset for the given object with Data
     ///

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -24,11 +24,12 @@ public class CreamAsset: Object {
         return ["data", "filePath"]
     }
 
-    private convenience init(objectID: String, propName: String, data: Data) {
+    private convenience init(objectID: String, propName: String, data: Data, force: Bool) {
         self.init()
         self.data = data
         self.uniqueFileName = "\(objectID)_\(propName)"
-        save(data: data, to: uniqueFileName)
+        
+        save(data: data, to: uniqueFileName, force: force)
     }
 
     private convenience init?(objectID: String, propName: String, url: URL) {
@@ -47,8 +48,9 @@ public class CreamAsset: Object {
         return CreamAsset.creamAssetDefaultURL().appendingPathComponent(uniqueFileName)
     }
 
-    func save(data: Data, to path: String) {
+    func save(data: Data, to path: String, force: Bool) {
         let url = CreamAsset.creamAssetDefaultURL().appendingPathComponent(path)
+        guard Data(contentsOf: url) == nil || force else { return }
         do {
             try data.write(to: url)
         } catch {
@@ -79,11 +81,13 @@ public class CreamAsset: Object {
     ///   - objectID: The object ID (key property of the Realm object) the asset will live on
     ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
     ///   - data: The file data
+    ///   - force: Whether to force a new save, even if the file already exists
     /// - Returns: A CreamAsset if it was successful
-    public static func create(objectID: String, propName: String, data: Data) -> CreamAsset? {
+    public static func create(objectID: String, propName: String, data: Data, force: Bool) -> CreamAsset? {
         return CreamAsset(objectID: objectID,
                           propName: propName,
-                          data: data)
+                          data: data,
+                          force: force)
     }
 
     /// Creates a new CreamAsset for the given object with Data
@@ -92,11 +96,13 @@ public class CreamAsset: Object {
     ///   - object: The object the asset will live on
     ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
     ///   - data: The file data
+    ///   - force: Whether to force a new save, even if the file already exists
     /// - Returns: A CreamAsset if it was successful
-    public static func create(object: CKRecordConvertible, propName: String, data: Data) -> CreamAsset? {
+    public static func create(object: CKRecordConvertible, propName: String, data: Data, force: Bool) -> CreamAsset? {
         return CreamAsset(objectID: object.recordID.recordName,
                           propName: propName,
-                          data: data)
+                          data: data,
+                          force: force)
     }
 
     /// Creates a new CreamAsset for the given object with a URL

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -55,7 +55,7 @@ public class CreamAsset: Object {
 
     func save(data: Data, to path: String, force: Bool = false) {
         let url = CreamAsset.creamAssetDefaultURL().appendingPathComponent(path)
-        guard try? Data(contentsOf: url) == nil || force else { return }
+        if let existingData = try? Data(contentsOf: url), !force { return }
         do {
             try data.write(to: url)
         } catch {


### PR DESCRIPTION
This PR adds support for Lists of the following types:
- Int
- String
- Bool
- Float
- Double
- Data

And fixes an issue where CreamAsset's could get duplicated if you created them multiple times with the same object/image.