### PR TITLE
Don't force unwrap storedData

### DIFF
--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -40,7 +40,7 @@ public class CreamAsset: Object {
     /// Cuz we only store the path of data, so we can't access data by `data` property
     /// So use this method if you want get the data of this object
     public func storedData() -> Data? {
-        return try! Data(contentsOf: filePath)
+        return try? Data(contentsOf: filePath)
     }
 
     public var filePath: URL {


### PR DESCRIPTION
My app has the option to save and restore backups of the user's data, so the contents of one Realm database are sometimes copied to another. That means `CreamAsset` objects can be copied without the underlying data being copied along with them. That causes IceCream to crash when force unwrapping `Data(contentsOf: filePath)`. And `storedData()` is already optional anyway, so there's no reason to force unwrap it anyway.