### PR TITLE
Allow toggling syncing on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![IceCream](https://i.loli.net/2017/11/18/5a104e5acfea5.png)
- 
+
 [![Version](https://img.shields.io/cocoapods/v/IceCream.svg?style=flat)](http://cocoapods.org/pods/IceCream)
 [![CI Status](http://img.shields.io/travis/caiyue1993/IceCream.svg?style=flat)](https://travis-ci.org/caiyue1993/IceCream)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![IceCream](https://i.loli.net/2017/11/18/5a104e5acfea5.png)
-
+ 
 [![Version](https://img.shields.io/cocoapods/v/IceCream.svg?style=flat)](http://cocoapods.org/pods/IceCream)
 [![CI Status](http://img.shields.io/travis/caiyue1993/IceCream.svg?style=flat)](https://travis-ci.org/caiyue1993/IceCream)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)


### PR DESCRIPTION
This pull request adds support to enable/disable syncing after initializing the SyncEngine, this is useful if, for example, the host app has a toggle to enable iCloud Sync for the user.