### PR TITLE
Bugfix/primary key int

### DIFF
--- a/IceCream/Classes/CKRecordRecoverable.swift
+++ b/IceCream/Classes/CKRecordRecoverable.swift
@@ -76,7 +76,7 @@ extension CKRecordRecoverable where Self: Object {
                 if let asset = record.value(forKey: prop.name) as? CKAsset {
                     recordValue = CreamAsset.parse(from: prop.name, record: record, asset: asset)
                 } else if let owner = record.value(forKey: prop.name) as? CKRecord.Reference, let ownerType = prop.objectClassName {
-                    recordValue = realm.dynamicObject(ofType: ownerType, forPrimaryKey: owner.recordID.recordName)
+                    recordValue = realm.dynamicObject(ofType: ownerType, forPrimaryKey: primaryKeyForRecordID(recordID: owner.recordID))
                     // Because we use the primaryKey as recordName when object converting to CKRecord
                 }
             default:
@@ -87,5 +87,14 @@ extension CKRecordRecoverable where Self: Object {
             }
         }
         return o
+    }
+    
+    /// The primaryKey in Realm could be type of Int or String. However the `recordName` is a String type, we need to make a check.
+    /// The reversed process happens in `recordID` property in `CKRecordConvertible` protocol.
+    ///
+    /// - Parameter recordID: the recordID that CloudKit sent to us
+    /// - Returns: the specific value of primaryKey in Realm
+    static func primaryKeyForRecordID(recordID: CKRecord.ID) -> Any {
+        return Int(recordID.recordName) ?? recordID.recordName
     }
 }

--- a/IceCream/Classes/CKRecordRecoverable.swift
+++ b/IceCream/Classes/CKRecordRecoverable.swift
@@ -13,7 +13,7 @@ public protocol CKRecordRecoverable {
 }
 
 extension CKRecordRecoverable where Self: Object {
-    func parseFromRecord(record: CKRecord, realm: Realm) -> Self? {
+    static func parseFromRecord(record: CKRecord, realm: Realm) -> Self? {
         let o = Self()
         for prop in o.objectSchema.properties {
             var recordValue: Any?

--- a/IceCream/Classes/SyncObject.swift
+++ b/IceCream/Classes/SyncObject.swift
@@ -91,7 +91,7 @@ extension SyncObject: Syncable {
     
     public func delete(recordID: CKRecord.ID) {
         DispatchQueue.main.async {
-            guard let object = self.realm.object(ofType: T.self, forPrimaryKey: recordID.recordName) else {
+            guard let object = self.realm.object(ofType: T.self, forPrimaryKey: T.primaryKeyForRecordID(recordID: recordID)) else {
                 // Not found in local realm database
                 return
             }

--- a/IceCream/Classes/SyncObject.swift
+++ b/IceCream/Classes/SyncObject.swift
@@ -72,7 +72,7 @@ extension SyncObject: Syncable {
     
     public func add(record: CKRecord) {
         DispatchQueue.main.async {
-            guard let object = T().parseFromRecord(record: record, realm: self.realm) else {
+            guard let object = T.parseFromRecord(record: record, realm: self.realm) else {
                 print("There is something wrong with the converson from cloud record to local object")
                 return
             }


### PR DESCRIPTION
This pr provides a better approach of #109. In detail:

1. Add support for the conversion of recordID to Int type primaryKey
2. Make the `parseFromRecord` method static

This should also fix the #96 issue.