### PR TITLE
Pass completion block in SyncEngine.pull

### DIFF
--- a/IceCream/Classes/PrivateDatabaseManager.swift
+++ b/IceCream/Classes/PrivateDatabaseManager.swift
@@ -164,8 +164,6 @@ final class PrivateDatabaseManager: DatabaseManager {
             case .success:
                 guard let syncObject = self.syncObjects.first(where: { $0.zoneID == zoneId }) else { return }
                 syncObject.zoneChangesToken = token
-                callback?()
-                print("Fetch records successfully in zone: \(zoneId))")
             case .retry(let timeToWait, _):
                 ErrorHandler.shared.retryOperationIfPossible(retryAfter: timeToWait, block: {
                     self.fetchChangesInZones(callback)
@@ -182,6 +180,12 @@ final class PrivateDatabaseManager: DatabaseManager {
                 }
             default:
                 return
+            }
+        }
+        
+        changesOp.fetchRecordZoneChangesCompletionBlock = { error in
+            if error == nil {
+                callback?()
             }
         }
         

--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -65,9 +65,12 @@ public final class SyncEngine {
 
 // MARK: Public Method
 extension SyncEngine {
+    
     /// Fetch data on the CloudKit and merge with local
-    public func pull(completion: (() -> Void)? = nil) {
-        databaseManager.fetchChangesInDatabase(completion)
+    ///
+    /// - Parameter completionHandler: Supported in the `privateCloudDatabase` when the fetch data process completes successfully, completionHandler will be called.
+    public func pull(completionHandler: (() -> Void)? = nil) {
+        databaseManager.fetchChangesInDatabase(completionHandler)
     }
     
     /// Push all existing local data to CloudKit
@@ -75,6 +78,7 @@ extension SyncEngine {
     public func pushAll() {
         databaseManager.syncObjects.forEach { $0.pushLocalObjectsToCloudKit() }
     }
+    
 }
 
 public enum Notifications: String, NotificationName {

--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -66,8 +66,8 @@ public final class SyncEngine {
 // MARK: Public Method
 extension SyncEngine {
     /// Fetch data on the CloudKit and merge with local
-    public func pull() {
-        databaseManager.fetchChangesInDatabase(nil)
+    public func pull(completion: (() -> Void)? = nil) {
+        databaseManager.fetchChangesInDatabase(completion)
     }
     
     /// Push all existing local data to CloudKit


### PR DESCRIPTION
As `DatabaseManager.fetchChangesInDatabase` supports passing in a completion block which is run once each zone is fetched lets pass that through as an optional void completion block.

This is a no-op for current users as the block is optional and defaults to nil but it means that we can now pass in a block which is only run once the pull is complete.

Whilst we could just simply observe the Realm itself for these changes there is no way to wait for a signal that all of a given batch (cloud pull) is done.