### PR TITLE
Add primary value for CKRecord name assertions

### DIFF
--- a/IceCream/Classes/CKRecordConvertible.swift
+++ b/IceCream/Classes/CKRecordConvertible.swift
@@ -55,6 +55,10 @@ extension CKRecordConvertible where Self: Object {
         switch primaryKeyProperty.type {
         case .string:
             if let primaryValueString = self[primaryKeyProperty.name] as? String {
+                // For more: https://developer.apple.com/documentation/cloudkit/ckrecord/id/1500975-init
+                assert(primaryValueString.allSatisfy({ $0.isASCII }), "Primary value for CKRecord name must contain only ASCII characters")
+                assert(primaryValueString.count <= 255, "Primary value for CKRecord name must not exceed 255 characters")
+                assert(!primaryValueString.starts(with: "_"), "Primary value for CKRecord name must not start with an underscore")
                 return CKRecord.ID(recordName: primaryValueString, zoneID: Self.zoneID)
             } else {
                 assertionFailure("\(primaryKeyProperty.name)'s value should be String type")
@@ -143,5 +147,3 @@ extension CKRecordConvertible where Self: Object {
     }
     
 }
-
-


### PR DESCRIPTION
Add assertions for issue #190 

I've considered checking validation and transform to a valid name if need.

```swift
if let primaryValueString = self[primaryKeyProperty.name] as? String {
    var recordName = primaryValueString
    if primaryValueString.allSatisfy({ $0.isASCII }) {
        if let data = primaryValueString.data(using: .ascii, allowLossyConversion: true),
            let string = String(data: data, encoding: .ascii) {
            recordName = string
        }
    }
    if primaryValueString.starts(with: "_") {
        recordName = "ice" + recordName
    }
    return CKRecord.ID(recordName: primaryValueString, zoneID: Self.zoneID)
}
```

But I think it's better for user to decide how to handle this issue. By the way, just make assertions won't have any other side effect or migration issue.