### PR TITLE
CreamAsset from URL no longer have to be converted to Data.

### DIFF
--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -19,14 +19,12 @@ import CloudKit
 /// So this is the deal.
 public class CreamAsset: Object {
     @objc dynamic private var uniqueFileName = ""
-    @objc dynamic private var data: Data?
     override public static func ignoredProperties() -> [String] {
-        return ["data", "filePath"]
+        return ["filePath"]
     }
 
-    private convenience init(objectID: String, propName: String, data: Data? = nil) {
+    private convenience init(objectID: String, propName: String) {
         self.init()
-        self.data = data
         self.uniqueFileName = "\(objectID)_\(propName)"
     }
     
@@ -80,11 +78,9 @@ public class CreamAsset: Object {
     ///   - shouldOverwrite: Whether to try and save the file even if an existing file exists for the same object.
     /// - Returns: A CreamAsset if it was successful
     public static func create(object: CKRecordConvertible, propName: String, data: Data, shouldOverwrite: Bool = true) -> CreamAsset? {
-        let creamAsset = CreamAsset(objectID: object.recordID.recordName,
-                                    propName: propName,
-                                    data: data)
-        save(data: data, to: creamAsset.uniqueFileName, shouldOverwrite: shouldOverwrite)
-        return creamAsset
+        return create(objectID: object.recordID.recordName,
+                      propName: propName,
+                      data: data)
     }
     
     /// Creates a new CreamAsset for the given object id with Data
@@ -97,8 +93,7 @@ public class CreamAsset: Object {
     /// - Returns: A CreamAsset if it was successful
     public static func create(objectID: String, propName: String, data: Data, shouldOverwrite: Bool = true) -> CreamAsset? {
         let creamAsset = CreamAsset(objectID: objectID,
-                                    propName: propName,
-                                    data: data)
+                                    propName: propName)
         save(data: data, to: creamAsset.uniqueFileName, shouldOverwrite: shouldOverwrite)
         return creamAsset
     }
@@ -111,14 +106,9 @@ public class CreamAsset: Object {
     ///   - url: The URL where the file located
     /// - Returns: A CreamAsset if it was successful
     public static func create(object: CKRecordConvertible, propName: String, url: URL) -> CreamAsset? {
-        let creamAsset = CreamAsset(objectID: object.recordID.recordName, propName: propName)
-        do {
-          try FileManager.default.copyItem(at: url, to: creamAsset.filePath)
-        } catch {
-            /// Log: copy item failed
-            return nil
-        }
-        return creamAsset
+        return create(objectID: object.recordID.recordName,
+                      propName: propName,
+                      url: url)
     }
     
     
@@ -130,11 +120,13 @@ public class CreamAsset: Object {
     /// - Returns: The CreamAsset if creates successful
     public static func create(objectID: String, propName: String, url: URL) -> CreamAsset? {
         let creamAsset = CreamAsset(objectID: objectID, propName: propName)
-        do {
-            try FileManager.default.copyItem(at: url, to: creamAsset.filePath)
-        } catch {
-            /// Log: copy item failed
-            return nil
+        if !FileManager.default.fileExists(atPath: creamAsset.filePath.path) {
+            do {
+                try FileManager.default.copyItem(at: url, to: creamAsset.filePath)
+            } catch {
+                /// Log: copy item failed
+                return nil
+            }
         }
         return creamAsset
     }

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -135,7 +135,7 @@ public class CreamAsset: Object {
     public static func create(objectID: String, propName: String, url: URL, shouldOverwrite: Bool = true) -> CreamAsset? {
         let creamAsset = CreamAsset(objectID: objectID, propName: propName)
         if shouldOverwrite {
-            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: creamAsset.filePath)
         }
         if !FileManager.default.fileExists(atPath: creamAsset.filePath.path) {
             do {

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -69,7 +69,8 @@ public class CreamAsset: Object {
         guard let url = asset.fileURL else { return nil }
         return CreamAsset.create(objectID: record.recordID.recordName,
                                  propName: propName,
-                                 url: url)
+                                 url: url,
+                                 shouldOverwrite: true)
     }
 
     // MARK: - Factory methods
@@ -135,7 +136,11 @@ public class CreamAsset: Object {
     public static func create(objectID: String, propName: String, url: URL, shouldOverwrite: Bool = true) -> CreamAsset? {
         let creamAsset = CreamAsset(objectID: objectID, propName: propName)
         if shouldOverwrite {
-            try? FileManager.default.removeItem(at: creamAsset.filePath)
+            do {
+                try FileManager.default.removeItem(at: creamAsset.filePath)
+            } catch {
+                // Os.log remove item failed error here
+            }
         }
         if !FileManager.default.fileExists(atPath: creamAsset.filePath.path) {
             do {

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -129,7 +129,7 @@ public class CreamAsset: Object {
     ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
     ///   - url: The location where asset locates
     /// - Returns: The CreamAsset if creates successful
-    static func create(objectID: String, propName: String, url: URL) -> CreamAsset? {
+    public static func create(objectID: String, propName: String, url: URL) -> CreamAsset? {
         let creamAsset = CreamAsset(objectID: objectID, propName: propName)
         if !FileManager.default.fileExists(atPath: creamAsset.filePath.path) {
             do {

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -86,7 +86,7 @@ public class CreamAsset: Object {
         let creamAsset = CreamAsset(objectID: objectID,
                                     propName: propName)
         do {
-            save(data: data, to: creamAsset.uniqueFileName, shouldOverwrite: shouldOverwrite)
+            try save(data: data, to: creamAsset.uniqueFileName, shouldOverwrite: shouldOverwrite)
             return creamAsset
         } catch {
             // Os.log error here
@@ -115,11 +115,13 @@ public class CreamAsset: Object {
     ///   - object: The object the asset will live on
     ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
     ///   - url: The URL where the file located
+    ///   - shouldOverwrite: Whether to try and save the file even if an existing file exists for the same object.
     /// - Returns: A CreamAsset if it was successful
-    public static func create(object: CKRecordConvertible, propName: String, url: URL) -> CreamAsset? {
+    public static func create(object: CKRecordConvertible, propName: String, url: URL, shouldOverwrite: Bool = true) -> CreamAsset? {
         return create(objectID: object.recordID.recordName,
                       propName: propName,
-                      url: url)
+                      url: url,
+                      shouldOverwrite: shouldOverwrite)
     }
     
     
@@ -128,9 +130,13 @@ public class CreamAsset: Object {
     ///   - objectID: The key to identify the object. Normally it's the recordName property of CKRecord.ID when recovering from CloudKit
     ///   - propName: The unique property name to identify this asset. e.g.: Dog Object may have multiple CreamAsset properties, so we need unique `propName`s to identify these.
     ///   - url: The location where asset locates
+    ///   - shouldOverwrite: Whether to try and save the file even if an existing file exists for the same object.
     /// - Returns: The CreamAsset if creates successful
-    public static func create(objectID: String, propName: String, url: URL) -> CreamAsset? {
+    public static func create(objectID: String, propName: String, url: URL, shouldOverwrite: Bool = true) -> CreamAsset? {
         let creamAsset = CreamAsset(objectID: objectID, propName: propName)
+        if shouldOverwrite {
+            try? FileManager.default.removeItem(at: url)
+        }
         if !FileManager.default.fileExists(atPath: creamAsset.filePath.path) {
             do {
                 try FileManager.default.copyItem(at: url, to: creamAsset.filePath)


### PR DESCRIPTION
This would resolve issue [208](https://github.com/caiyue1993/IceCream/issues/208) by using copyItem from the source to the destination URL.